### PR TITLE
#35 - EDITOR with arguments produces backtrace

### DIFF
--- a/src/tito/release.py
+++ b/src/tito/release.py
@@ -733,7 +733,7 @@ class CvsReleaser(Releaser):
             editor = 'vi'
             if "EDITOR" in os.environ:
                 editor = os.environ["EDITOR"]
-            subprocess.call([editor, name])
+            subprocess.call(editor.split() + [name])
 
         cmd = 'cvs commit -F %s' % name
         debug("CVS commit command: %s" % cmd)

--- a/src/tito/tagger.py
+++ b/src/tito/tagger.py
@@ -221,7 +221,7 @@ class VersionTagger(object):
                     editor = 'vi'
                     if "EDITOR" in os.environ:
                         editor = os.environ["EDITOR"]
-                    subprocess.call([editor, name])
+                    subprocess.call(editor.split() + [name])
 
                 os.lseek(fd, 0, 0)
                 file = os.fdopen(fd)


### PR DESCRIPTION
Currently EDITOR is assumed to be a single word (e.g. 'vi') and does
not handle and editor with arguments (e.g. 'emacs --quick -nw') due to
the way subprocess.call is invoked.  This patch allows either to work
in both VersionTagger._make_changelog and
CvsReleaser._cvs_user_confirm_commit_msg.
