### PR TITLE
Add support for customizable changelog formats

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -710,7 +710,7 @@ class InitModule(BaseCliModule):
             out_f.write(
                 "default_tagger = %s\n" % 'tito.tagger.VersionTagger')
             out_f.write("changelog_do_not_remove_cherrypick = 0\n")
-            out_f.write("changelog_with_email = 1\n")
+            out_f.write("changelog_format = %s %(ae)\n")
             out_f.close()
             print("   - wrote %s" % GLOBAL_BUILD_PROPS_FILENAME)
 

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -52,9 +52,16 @@ This option is used in project specific tito.props only, and allows that project
 tagger::
 This option is used in project specific tito.props only, and allows that project to override the default_tagger defined in rel-eng/tito.props.
 
+changelog_format::
+This option is used to control the formatting of entries when
+generating changelog entries.  The default value is "%s (%ae)".  See
+PRETTY FORMATS in git-log(1) for more information.
+
 changelog_with_email::
-If set to 0, then entries in changelog (subject of commits) are not followed by
-email of commiter. Default is 1.
+If set to 0, then entries in changelog (subject of commits) are not
+followed by email of commiter. Default is 1.  This option is
+deprecated and provided for backwards-compatibility only.  New
+configurations should consider changelog_format instead.
 
 changelog_do_not_remove_cherrypick::
 If set to 0, it will not remove from cherry picked commits the part "(cherry


### PR DESCRIPTION
This adds a new option, changelog_format, which allows specifying the
full format of generated changelog entries.  This also deprecates use
of changelog_with_email, since it is a subset of a fully-customizable
changelog format.
