### PR TITLE
Fix changelog_format typo in default config

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -710,7 +710,7 @@ class InitModule(BaseCliModule):
             out_f.write(
                 "default_tagger = %s\n" % 'tito.tagger.VersionTagger')
             out_f.write("changelog_do_not_remove_cherrypick = 0\n")
-            out_f.write("changelog_format = %s %(ae)\n")
+            out_f.write("changelog_format = %s (%ae)\n")
             out_f.close()
             print("   - wrote %s" % GLOBAL_BUILD_PROPS_FILENAME)
 


### PR DESCRIPTION
This was being wrongfully interpolated by ConfigParser and causing a
backtrace.
