### PR TITLE
New releaser class : RsyncReleaser, also refactored YumRepoReleaser to inherit code from RsyncReleaser

### DIFF
--- a/src/tito/release.py
+++ b/src/tito/release.py
@@ -227,9 +227,8 @@ class Releaser(object):
 
         return new_files, copied_files, old_files
 
-
 class RsyncReleaser(Releaser):
-	"""
+    """
 A releaser which will rsync from a remote host, build the desired packages,
 plug them in, and upload to server.
 
@@ -239,114 +238,100 @@ WARNING: This will not work in all
 situations, depending on the current OS, and the mock target you
 are attempting to use.
 """
-	REQUIRED_CONFIG = ['rsync', 'builder']
+    REQUIRED_CONFIG = ['rsync', 'builder']
 
-	# Default list of packages to copy
-	filetypes = ['rpm', 'srpm', 'tgz' ]
+    # Default list of packages to copy
+    filetypes = ['rpm', 'srpm', 'tgz' ]
 
-	def __init__(self, name=None, version=None, tag=None, build_dir=None,
-				 pkg_config=None, global_config=None, user_config=None,
-				 target=None, releaser_config=None, no_cleanup=False):
-		Releaser.__init__(self, name, version, tag, build_dir, pkg_config,
-			global_config, user_config, target, releaser_config, no_cleanup)
+    def __init__(self, name=None, version=None, tag=None, build_dir=None,
+            pkg_config=None, global_config=None, user_config=None,
+            target=None, releaser_config=None, no_cleanup=False):
+        Releaser.__init__(self, name, version, tag, build_dir, pkg_config,
+                global_config, user_config, target, releaser_config, no_cleanup)
 
-		self.build_dir = build_dir
+        self.build_dir = build_dir
 
+        # Use the builder from the release target, rather than the default
+        # one defined for this git repo or sub-package:
+        self.builder = create_builder(name, tag,
+                version, pkg_config,
+                build_dir, global_config, user_config, self.builder_args,
+                builder_class=self.releaser_config.get(self.target, 'builder'))
 
-		# Use the builder from the release target, rather than the default
-		# one defined for this git repo or sub-package:
-		self.builder = create_builder(name, tag,
-			version, pkg_config,
-			build_dir, global_config, user_config, self.builder_args,
-			builder_class=self.releaser_config.get(self.target, 'builder'))
+    def release(self, dry_run=False):
+        self.dry_run = dry_run
 
-	def release(self, dry_run=False):
-		self.dry_run = dry_run
+        # Should this run?
+        self.builder.no_cleanup = self.no_cleanup
+        self.builder.tgz()
+        self.builder.srpm()
+        self.builder._rpm()
+        self.builder.cleanup()
 
-		# Should this run?
-		self.builder.no_cleanup = self.no_cleanup
-		self.builder.tgz()
-		self.builder.srpm()
-		self.builder._rpm()
-		self.builder.cleanup()
+        # Make a temp directory to sync the existing repo contents into:
+        self.temp_dir = mkdtemp(dir=self.build_dir, prefix="temp_dir-")
 
-		# Make a temp directory to sync the existing repo contents into:
-		self.temp_dir = mkdtemp(dir=self.build_dir, prefix="temp_dir-")
+        self.rsync_from_remote()
+        self.copy_files_to_temp_dir()
+        self.process_packages()
+        self.rsync_to_remote()
 
-		self.rsync_from_remote()
-		self.copy_files_to_temp_dir()
-		self.process_packages()
-		self.rsync_to_remote()
+    def rsync_from_remote(self):
+        rsync_locations = self.releaser_config.get(self.target, 'rsync').split(" ")
+        for rsync_location in rsync_locations:
+            if RSYNC_USERNAME in os.environ:
+                print("%s set, using rsync username: %s" % (RSYNC_USERNAME,
+                        os.environ[RSYNC_USERNAME]))
+                rsync_location = "%s@%s" % (os.environ[RSYNC_USERNAME], rsync_location)
 
-	def rsync_from_remote(self):
-		rsync_locations = self.releaser_config.get(self.target, 'rsync').split(" ")
-		for rsync_location in rsync_locations:
-			if RSYNC_USERNAME in os.environ:
-				print("%s set, using rsync username: %s" % (RSYNC_USERNAME,
-															os.environ[RSYNC_USERNAME]))
-				rsync_location = "%s@%s" % (os.environ[RSYNC_USERNAME], rsync_location)
+            os.chdir(self.temp_dir)
+            print("rsync: %s -> %s" % (rsync_location, self.temp_dir))
+            self.rsync_location = rsync_location
+            output = run_command("rsync -rlvz %s %s" % (rsync_location, self.temp_dir))
+            debug(output)
+    def rsync_to_remote(self):
+        print("rsync: %s -> %s" % (self.rsync_location, self.rsync_location))
+        os.chdir(self.temp_dir)
+        # TODO: configurable rsync options?
+        cmd = "rsync -rlvz --delete %s/ %s" %\
+              (self.temp_dir, self.rsync_location)
+        if self.dry_run:
+            self.print_dry_run_warning(cmd)
+        else:
+            output = run_command(cmd)
+            debug(output)
+        if not self.no_cleanup:
+            debug("Cleaning up [%s]" % self.temp_dir)
+            os.chdir("/")
+            rmtree(self.temp_dir)
+        else:
+            print("WARNING: leaving %s (--no-cleanup)" % self.temp_dir)
+    def copy_files_to_temp_dir(self):
+        os.chdir(self.temp_dir)
 
-			os.chdir(self.temp_dir)
-			print("rsync: %s -> %s" % (rsync_location, self.temp_dir))
-			self.rsync_location = rsync_location
-			output = run_command("rsync -rlvz %s %s" % (rsync_location, self.temp_dir))
-			debug(output)
-	def rsync_to_remote(self):
-		print("rsync: %s -> %s" % (self.rsync_location, self.rsync_location))
-		os.chdir(self.temp_dir)
-		# TODO: configurable rsync options?
-		cmd = "rsync -rlvz --delete %s/ %s" %\
-			  (self.temp_dir, self.rsync_location)
-		if self.dry_run:
-			self.print_dry_run_warning(cmd)
-		else:
-			output = run_command(cmd)
-			debug(output)
-		if not self.no_cleanup:
-			debug("Cleaning up [%s]" % self.temp_dir)
-			os.chdir("/")
-			rmtree(self.temp_dir)
-		else:
-			print("WARNING: leaving %s (--no-cleanup)" % self.temp_dir)
+        # overwrite default self.filetypes if filetypes option is specified in config
+        if self.releaser_config.has_option(self.target,'filetypes'):
+            self.filetypes = self.releaser_config.get(self.target, 'filetypes').split(" ")
 
-	def copy_files_to_temp_dir(self):
-		os.chdir(self.temp_dir)
+        for artifact in self.builder.artifacts:
+            if artifact.endswith('.tar.gz'): artifact_type = 'tgz'
+            elif artifact.endswith('src.rpm'): artifact_type = 'srpm'
+            elif artifact.endswith('.rpm'): artifact_type = 'rpm'
+            else: continue
 
-		# overwrite default self.filetypes if filetypes option is specified in config
-		if self.releaser_config.has_option(self.target,'filetypes'):
-			self.filetypes = self.releaser_config.get(self.target, 'filetypes').split(" ")
-
-		for artifact in self.builder.artifacts:
-			if artifact.endswith('.tar.gz'): artifact_type = 'tgz'
-			elif artifact.endswith('src.rpm'): artifact_type = 'srpm'
-			elif artifact.endswith('.rpm'): artifact_type = 'rpm'
-
-			if artifact_type in self.filetypes:
-				copy(artifact, self.temp_dir)
-				print("copy: %s > %s" % (artifact, self.temp_dir))
-	def process_packages(self):
-		''' no-op. This will be overloaded by a subclass if needed. '''
-		pass
-
-
-
-
-	def _read_rpm_header(self, ts, new_rpm_path):
-		"""
-Read RPM header for the given file.
-"""
-		fd = os.open(new_rpm_path, os.O_RDONLY)
-		header = ts.hdrFromFdno(fd)
-		os.close(fd)
-		return header
-
-	def cleanup(self):
-		""" No-op, we clean up during self.release() """
-		pass
+            if artifact_type in self.filetypes:
+                copy(artifact, self.temp_dir)
+                print("copy: %s > %s" % (artifact, self.temp_dir))
+    def process_packages(self):
+        """ no-op. This will be overloaded by a subclass if needed. """
+        pass
+    def cleanup(self):
+        """ No-op, we clean up during self.release() """
+        pass
 
 
 class YumRepoReleaser(RsyncReleaser):
-	"""
+    """
     A releaser which will rsync down a yum repo, build the desired packages,
     plug them in, update the repodata, and push the yum repo back out.
 
@@ -357,45 +342,53 @@ class YumRepoReleaser(RsyncReleaser):
     are attempting to use.
     """
 
-	# Default list of packages to copy
-	filetypes = ['rpm' ]
+    # Default list of packages to copy
+    filetypes = ['rpm' ]
 
-	def process_packages(self, dry_run=False):
-		print("Refreshing yum repodata...")
-		os.chdir(self.temp_dir)
-		output = run_command("createrepo ./")
-		debug(output)
-		self.prune_other_versions()
-	def prune_other_versions(self):
-		"""
-		Cleanout any other version of the package we just built.
+    def _read_rpm_header(self, ts, new_rpm_path):
+        """
+Read RPM header for the given file.
+"""
+        fd = os.open(new_rpm_path, os.O_RDONLY)
+        header = ts.hdrFromFdno(fd)
+        os.close(fd)
+        return header
 
-		Both older and newer packages will be removed (can be used
-		to downgrade the contents of a yum repo).
-		"""
-		os.chdir(self.temp_dir)
-		rpm_ts = rpm.TransactionSet()
-		self.new_rpm_dep_sets = {}
-		for artifact in self.builder.artifacts:
-			if artifact.endswith(".rpm") and not artifact.endswith(".src.rpm"):
-				header = self._read_rpm_header(rpm_ts, artifact)
-				self.new_rpm_dep_sets[header['name']] = header.dsOfHeader()
+    def process_packages(self):
+        print("Refreshing yum repodata...")
+        os.chdir(self.temp_dir)
+        output = run_command("createrepo ./")
+        debug(output)
+        self.prune_other_versions()
+    def prune_other_versions(self):
+        """
+        Cleanout any other version of the package we just built.
 
-		# Now cleanout any other version of the package we just built,
-		# both older or newer. (can be used to downgrade the contents
-		# of a yum repo)
-		for filename in os.listdir(self.temp_dir):
-			if not filename.endswith(".rpm"):
-				continue
-			hdr = self._read_rpm_header(rpm_ts,
-				os.path.join(self.temp_dir, filename))
-			if hdr['name'] in self.new_rpm_dep_sets:
-				dep_set = hdr.dsOfHeader()
-				if dep_set.EVR() < self.new_rpm_dep_sets[hdr['name']].EVR():
-					print("Deleting old package: %s" % filename)
-					run_command("rm %s" % os.path.join(self.temp_dir,
-						filename))
+        Both older and newer packages will be removed (can be used
+        to downgrade the contents of a yum repo).
+        """
+        os.chdir(self.temp_dir)
+        rpm_ts = rpm.TransactionSet()
+        self.new_rpm_dep_sets = {}
+        for artifact in self.builder.artifacts:
+            if artifact.endswith(".rpm") and not artifact.endswith(".src.rpm"):
+                header = self._read_rpm_header(rpm_ts, artifact)
+                self.new_rpm_dep_sets[header['name']] = header.dsOfHeader()
 
+        # Now cleanout any other version of the package we just built,
+        # both older or newer. (can be used to downgrade the contents
+        # of a yum repo)
+        for filename in os.listdir(self.temp_dir):
+            if not filename.endswith(".rpm"):
+                continue
+            hdr = self._read_rpm_header(rpm_ts,
+                os.path.join(self.temp_dir, filename))
+            if hdr['name'] in self.new_rpm_dep_sets:
+                dep_set = hdr.dsOfHeader()
+                if dep_set.EVR() < self.new_rpm_dep_sets[hdr['name']].EVR():
+                    print("Deleting old package: %s" % filename)
+                    run_command("rm %s" % os.path.join(self.temp_dir,
+                        filename))
 
 class FedoraGitReleaser(Releaser):
 


### PR DESCRIPTION
...ser.

Refactored YumRepoReleaser to inherit most code from RsyncReleaser.

RsyncReleaser takes an optional argument "filetypes" from releasers.conf
which specifies what type of packages should be rsynced

[rsync_test-example]
releaser = tito.release.RsyncReleaser
builder = tito.builder.MockBuilder
builder.mock = fedora-16-x86_64
filetypes = tgz rpm srpm
rsync = /tmp/rsync_repo/

in case of YumRepoReleaser default filetypes is of course only rpm.
