### PR TITLE
Optionally print stacktrace whenever error_out is hit

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import commands
+import traceback
 
 DEFAULT_BUILD_DIR = "/tmp/tito"
 DEFAULT_BUILDER = "default_builder"


### PR DESCRIPTION
Just a little something I did locally today to help me debug something.  Feel free to rework/disregard this pull request as you wish.  It certainly won't offend me. :)

Originally I tried to pass traceback.format_stack() to the debug method but it wasn't printing things out as I hoped.
