### PR TITLE
Handle stderr noise getting from remote server

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -24,7 +24,7 @@ DEFAULT_BUILD_DIR = "/tmp/tito"
 DEFAULT_BUILDER = "default_builder"
 DEFAULT_TAGGER = "default_tagger"
 GLOBALCONFIG_SECTION = "globalconfig"
-
+SHA_RE=re.compile(r'\b[0-9a-f]{30,}\b')
 
 # Define some shortcuts to fully qualified Builder classes to make things
 # a little more concise for CLI users. Mock is probably the only one this
@@ -182,6 +182,10 @@ def find_git_root():
         cdup = "./"
     return os.path.abspath(cdup)
 
+def extract_sha1(output):
+    match = SHA_RE.search(output)
+    if match: return match.group(0)
+    else: return ""
 
 def run_command(command):
     debug(command)
@@ -221,6 +225,7 @@ def get_local_tag_sha1(tag):
     tag_sha1 = run_command(
             "git ls-remote ./. --tag %s | awk '{ print $1 ; exit }'"
             % tag)
+    tag_sha1 = extract_sha1(tag_sha1)
     return tag_sha1
 
 
@@ -263,6 +268,7 @@ def get_remote_tag_sha1(tag):
     cmd = "git ls-remote %s --tag %s | awk '{ print $1 ; exit }'" % \
             (repo_url, tag)
     upstream_tag_sha1 = run_command(cmd)
+    upstream_tag_sha1 = extract_sha1(upstream_tag_sha1)
     return upstream_tag_sha1
 
 
@@ -384,6 +390,7 @@ def get_build_commit(tag, test=False):
         tag_sha1 = run_command(
                 "git ls-remote ./. --tag %s | awk '{ print $1 ; exit }'"
                 % tag)
+        tag_sha1 = extract_sha1(tag_sha1)
         commit_id = run_command('git rev-list --max-count=1 %s' % tag_sha1)
         return commit_id
 

--- a/test/unit/common-tests.py
+++ b/test/unit/common-tests.py
@@ -75,6 +75,11 @@ class CommonTests(unittest.TestCase):
         line = "this isn't a version fool.\n"
         self.assertEquals(line, replace_version(line, "2.5.3"))
 
+    def test_extract_sha1(self):
+        ls_remote_output = "Could not chdir to home directory\n" + \
+                           "fe87e2b75ed1850718d99c797cc171b88bfad5ca ref/origin/sometag"
+        self.assertEquals("fe87e2b75ed1850718d99c797cc171b88bfad5ca",
+                          extract_sha1(ls_remote_output))
 
 class VersionMathTest(unittest.TestCase):
     def test_increase_version_minor(self):


### PR DESCRIPTION
Use regular expression to extract the SHA1 from the `git ls-remote` call
response. The reason is that there might be some messages in the
response going to stderr, that are captured when using run_command,
e.g.:

```
Could not chdir to home directory /home/johndoe: No such file or directory
fe87e2b75ed1850718d99c797cc171b88bfad5ca refs/tags/my-awesome-lib-1.0.1-1
```

I used 30 and more characters for the regular expression because I was
not sure the SHA1 is always shown as 40 characters. However we can be
quite certain that the word of 30 and more [0-9a-f] characters is a
SHA1.
