### PR TITLE
pass in arguments to builder

### DIFF
--- a/src/tito/builder.py
+++ b/src/tito/builder.py
@@ -867,8 +867,8 @@ class MockBuilder(Builder):
             self.mock_cmd_args = "%s --no-clean --no-cleanup-after" % \
                     (self.mock_cmd_args)
 
-        if 'args' in args:
-            self.mock_cmd_args = "%s %s" % (self.mock_cmd_args, args['args'])
+        if 'mock_args' in args:
+            self.mock_cmd_args = "%s %s" % (self.mock_cmd_args, args['mock_args'])
 
         # TODO: error out if mock package is not installed
 


### PR DESCRIPTION
Adding ability to pass in args to builders from releasers.conf using builders.args config item.
## TEST
- mkdir /tmp/rheltest
- change rsync location in releasers.conf of candlepin to /tmp/rheltest
- attempt to build candlepin with tito release yum-rhel-x86_64
- watch it fail.

Now make it work with:
- add builder.args = -D "reqcpdeps 1" to the yum-rhel-x86_64 section of releasers.conf in candlepin
- now build with  tito release yum-rhel-x86_64
- build should work and rpms should appear in /tmp/rheltest

If that works that means it used candlepin-deps in mock.
