### PR TITLE
add a --scratch option for KojiReleaser

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -468,6 +468,10 @@ class ReleaseModule(BaseCliModule):
                 action="store_true", default=False,
                 help="Do not perform a build after a DistGit commit")
 
+        self.parser.add_option("-s", "--scratch", dest="scratch",
+                action="store_true",
+                help="Perform a scratch build in Koji")
+
 #        self.parser.add_option("--list-tags", dest="list_tags",
 #                action="store_true",
 #                help="List tags for which we build this package",
@@ -620,7 +624,8 @@ class ReleaseModule(BaseCliModule):
                     releaser_config=releaser_config,
                     no_cleanup=self.options.no_cleanup)
             releaser.release(dry_run=self.options.dry_run,
-                    no_build=self.options.no_build)
+                    no_build=self.options.no_build,
+                    scratch=self.options.scratch)
             releaser.cleanup()
 
             # Make sure we go back to where we started, otherwise multiple

--- a/src/tito/release.py
+++ b/src/tito/release.py
@@ -128,7 +128,7 @@ class Releaser(object):
         debug("Parsed custom builder args: %s" % args)
         return args
 
-    def release(self, dry_run=False):
+    def release(self, dry_run=False, no_build=False, scratch=False):
         pass
 
     def cleanup(self):
@@ -275,7 +275,7 @@ class RsyncReleaser(Releaser):
                 build_dir, global_config, user_config, self.builder_args,
                 builder_class=self.releaser_config.get(self.target, 'builder'))
 
-    def release(self, dry_run=False):
+    def release(self, dry_run=False, no_build=False, scratch=False):
         self.dry_run = dry_run
 
         # Should this run?
@@ -455,7 +455,7 @@ class FedoraGitReleaser(Releaser):
                                                 self.git_branches)
         self.build_targets = build_target_parser.get_build_targets()
 
-    def release(self, dry_run=False, no_build=False):
+    def release(self, dry_run=False, no_build=False, scratch=False):
         self.dry_run = dry_run
         self.no_build = no_build
         self._git_release()
@@ -719,7 +719,7 @@ class CvsReleaser(Releaser):
             self.cvs_branches = \
                 self.releaser_config.get(target, "branches").split(" ")
 
-    def release(self, dry_run=False):
+    def release(self, dry_run=False, no_build=False, scratch=False):
         self.dry_run = dry_run
 
         self._cvs_release()
@@ -959,8 +959,9 @@ class KojiReleaser(Releaser):
 
         self.skip_srpm = False
 
-    def release(self, dry_run=False):
+    def release(self, dry_run=False, no_build=False, scratch=False):
         self.dry_run = dry_run
+        self.scratch = scratch
 
         self._koji_release()
 
@@ -978,7 +979,7 @@ class KojiReleaser(Releaser):
         if 'KOJI_OPTIONS' in self.builder.user_config:
             koji_opts = self.builder.user_config['KOJI_OPTIONS']
 
-        if 'SCRATCH' in os.environ and os.environ['SCRATCH'] == '1':
+        if self.scratch or ('SCRATCH' in os.environ and os.environ['SCRATCH'] == '1'):
             koji_opts = ' '.join([koji_opts, '--scratch'])
 
         # TODO: need to re-do this metaphor to use release targets instead:

--- a/tito.8.asciidoc
+++ b/tito.8.asciidoc
@@ -206,6 +206,8 @@ Run all release targets starting with the given string. (i.e.
 if you have defined release targets yum-f15 and yum-f14 in releasers.conf,
 --all-starting-with=yum will run only these targets, and ignore any others.)
 
+--scratch::
+Perform a scratch build in Koji
 
 `tito report`
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Add a command-line option of --scratch to perform a scratch
build in Koji.  This is easier to use than always setting
the environment variable of SCRATCH=1.
