### PR TITLE
Fixed check for existing tag

### DIFF
--- a/src/tito/tagger.py
+++ b/src/tito/tagger.py
@@ -445,7 +445,7 @@ class VersionTagger(object):
 
     def _check_tag_does_not_exist(self, new_tag):
         status, output = commands.getstatusoutput(
-            'git tag | grep %s' % new_tag)
+            'git tag -l %s|grep ""' % new_tag)
         if status == 0:
             raise Exception("Tag %s already exists!" % new_tag)
 


### PR DESCRIPTION
We use suffix in relase number to indicate build in a branch. Builds from master have no suffix. When we had package-1.2.3-4h built in branch and was trying to tag package-1.2.3-4 in master the check failed as the new tag was substring of the other tag and grep matches that.
