### PR TITLE
Do not create patch if there are binary files

### DIFF
--- a/src/tito/builder.py
+++ b/src/tito/builder.py
@@ -828,6 +828,11 @@ class UpstreamBuilder(NoTgzBuilder):
         debug("Generating patch with: %s" % patch_command)
         output = run_command(patch_command)
         print(output)
+        (status, output) = commands.getstatusoutput(
+            "grep 'Binary files .* differ' %s " % patch_file)
+        if status == 0 and output != "":
+            error_out("You are doomed. Diff contains binary files. You can not use this builder")
+
         # Creating two copies of the patch here in the temp build directories
         # just out of laziness. Some builders need sources in SOURCES and
         # others need them in the git copy. Being lazy here avoids one-off

--- a/src/tito/distributionbuilder.py
+++ b/src/tito/distributionbuilder.py
@@ -27,6 +27,11 @@ class DistributionBuilder(UpstreamBuilder):
                % (self.rpmbuild_gitcopy, self.project_name, self.upstream_version, self.build_version, self.git_commit_id))
         self.patch_files = output.split("\n")
         for p_file in self.patch_files:
+            (status, output) = commands.getstatusoutput(
+                "grep 'Binary files .* differ' %s/%s " % (self.rpmbuild_gitcopy, p_file))
+            if status == 0 and output != "":
+                error_out("You are doomed. Diff contains binary files. You can not use this builder")
+
             run_command("cp %s/%s %s" % (self.rpmbuild_gitcopy, p_file, self.rpmbuild_sourcedir))
 
         (patch_number, patch_insert_index, patch_apply_index, lines) = self._patch_upstream()


### PR DESCRIPTION
"git diff" can accept --binary, which will produce diff with binary content. But patch does not understood
such diff, so we are doomed. Diff with binary file will produce

```
Binary files /dev/null and b/app/assets/images/false.png differ
diff --git a/app/assets/images/foreman.png b/app/assets/images/foreman.png
new file mode 100644
index 0000000..8815824
```

And patch will accept such syntax but will not create the file. Not even empty one.
So this result in silently throwing away some changes.
