### PR TITLE
Configure rsync to preserve timestamps and file permissions

### DIFF
--- a/releasers.conf.5.asciidoc
+++ b/releasers.conf.5.asciidoc
@@ -101,10 +101,11 @@ EXAMPLE
  cvsroot = :gserver:cvs.example.com:/cvs/dist
  branches = FEDORA-15
 
- ; rsync tgz file to remote site
+ ; rsync tgz file to remote site with custom rsync arguments
  [rsync]
  releaser = tito.release.RsyncReleaser
  builder = tito.builder.MockBuilder
  builder.mock = fedora-15-x86_64
  filetypes = tgz
  rsync = remoteserver.org:/srv/tarballs/
+ rsync_args = -rlvzpt


### PR DESCRIPTION
As configured rsync would clobber all the file timstamps in the Yum repo, so that everything appeared to have been updated. The rsync command has been updated to ensure that timestamps and file permissions are preserved.
