### PR TITLE
Fix unhandled exception when trying to reference koji_tags

### DIFF
--- a/src/tito/release.py
+++ b/src/tito/release.py
@@ -289,8 +289,7 @@ class RsyncReleaser(Releaser):
                 version, pkg_config,
                 build_dir, global_config, user_config, self.builder_args,
                 builder_class=self.releaser_config.get(self.target, 'builder'))
-        if self.releaser_config.config.has_option(koji_tag, "scl"):
-                self.builder.scl = self.releaser_config.config.get(koji_tag, "scl")
+
 
     def release(self, dry_run=False, no_build=False, scratch=False):
         self.dry_run = dry_run


### PR DESCRIPTION
Fixes this traceback:

Releasing to target: test-el6-x86_64
Working in: /tmp/tito/release-adagios-ffd9f2b328fb0a2226042b0b3ce1a5c4e4d95af4TRmZQM
Traceback (most recent call last):
  File "/usr/bin/tito", line 23, in <module>
    CLI().main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 94, in main
    return module.main(argv)
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 634, in main
    auto_accept=self.options.auto_accept)
  File "/usr/lib/python2.7/site-packages/tito/release.py", line 399, in **init**
    prefix="yumrepo-")
  File "/usr/lib/python2.7/site-packages/tito/release.py", line 292, in **init**
    if self.releaser_config.config.has_option(koji_tag, "scl"):
AttributeError: ConfigParser instance has no attribute 'config'
