### PR TITLE
add missing import of commands

### DIFF
--- a/src/tito/distributionbuilder.py
+++ b/src/tito/distributionbuilder.py
@@ -2,7 +2,7 @@ import os
 
 from tito.builder import UpstreamBuilder
 from tito.common import debug, run_command
-
+import commands
 
 class DistributionBuilder(UpstreamBuilder):
     """ This class is used for building packages for distributions.


### PR DESCRIPTION
addressing:
Traceback (most recent call last):
  File "/usr/bin/tito", line 23, in <module>
    CLI().main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 94, in main
    return module.main(argv)
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 638, in main
    scratch=self.options.scratch)
  File "/usr/lib/python2.7/site-packages/tito/release.py", line 490, in release
    self._git_release()
  File "/usr/lib/python2.7/site-packages/tito/release.py", line 507, in _git_release
    self.builder.tgz()
  File "/usr/lib/python2.7/site-packages/tito/builder.py", line 784, in tgz
    self.patch_upstream()
  File "/usr/lib/python2.7/site-packages/tito/distributionbuilder.py", line 34, in patch_upstream
    (status, output) = commands.getstatusoutput(
NameError: global name 'commands' is not defined
