### PR TITLE
import error_out from tito.common

### DIFF
--- a/src/tito/distributionbuilder.py
+++ b/src/tito/distributionbuilder.py
@@ -1,7 +1,7 @@
 import os
 
 from tito.builder import UpstreamBuilder
-from tito.common import debug, run_command
+from tito.common import debug, run_command, error_out
 import commands
 
 class DistributionBuilder(UpstreamBuilder):


### PR DESCRIPTION
addressing:

```
    $ tito release git-sat
    Will release to the following targets: git-sat
    Checking for tag [katello-1.4.2-4-sat] in git repo [ssh://git.corp.redhat.com/srv/git/engineering/katello]
    Releasing to target: git-sat
    Working in: /tmp/tito/release-katello-6a0e027d9e284d65e3407e7060e98ccf9d48b2fdiD7jdk
    Building upstream tgz for tag [katello-1.4.2-1]
    Checking for tag [katello-1.4.2-1] in git repo [ssh://git.corp.redhat.com/srv/git/engineering/katello]
    Creating katello-1.4.2.tar.gz from git tag: 507e03d5743fd2f7609d5bca80ed1e1b7d302fc4...
    Traceback (most recent call last):
      File "/usr/bin/tito", line 23, in <module>
        CLI().main(sys.argv[1:])
      File "/usr/lib/python2.6/site-packages/tito/cli.py", line 94, in main
        return module.main(argv)
      File "/usr/lib/python2.6/site-packages/tito/cli.py", line 638, in main
        scratch=self.options.scratch)
      File "/usr/lib/python2.6/site-packages/tito/release.py", line 490, in release
        self._git_release()
      File "/usr/lib/python2.6/site-packages/tito/release.py", line 507, in _git_release
        self.builder.tgz()
      File "/usr/lib/python2.6/site-packages/tito/builder.py", line 784, in tgz
        self.patch_upstream()
      File "/usr/lib/python2.6/site-packages/tito/distributionbuilder.py", line 37, in patch_upstream
        error_out("You are doomed. Diff contains binary files. You can not use this builder")
    NameError: global name 'error_out' is not defined
```
