### PR TITLE
allow multiline blacklist/whitelist

### DIFF
--- a/src/tito/release.py
+++ b/src/tito/release.py
@@ -1052,13 +1052,13 @@ class KojiReleaser(Releaser):
         """ Return true if package is whitelisted in tito.props"""
         return self.builder.config.has_option(koji_tag, "whitelist") and \
             get_project_name(self.builder.build_tag, scl) in self.builder.config.get(koji_tag,
-                        "whitelist").strip().split(" ")
+                        "whitelist").strip().split()
 
     def __is_blacklisted(self, koji_tag, scl):
         """ Return true if package is blacklisted in tito.props"""
         return self.builder.config.has_option(koji_tag, "blacklist") and \
             get_project_name(self.builder.build_tag, scl) in self.builder.config.get(koji_tag,
-                        "blacklist").strip().split(" ")
+                        "blacklist").strip().split()
 
     def _submit_build(self, executable, koji_opts, tag, srpm_location):
         """ Submit srpm to brew/koji. """


### PR DESCRIPTION
Since Python ConfigParser allows line continuation using one or more
whitespace characters on the next line, I was able to add support for
multiline splitting of blacklist/whitelist config values.

We have so many that is is annoying to have them on one line. Split method,
called without parameters, splits on any whitespace (instead of space which
was used previously).

If it would be possible to release new version for me, this would be
awesome, because I mis-pushed into our dist git repo already the change (I
had information from Mirek tito already allows that) and now I need to
either revert all my work or to bump the minimum tito version requirement
:-)

Thanks!
