### PR TITLE
docs clean up and additions for build_targets

### DIFF
--- a/releasers.conf.5.asciidoc
+++ b/releasers.conf.5.asciidoc
@@ -4,7 +4,8 @@ include::man.asciidoc[]
 
 NAME
 ----
-releasers.conf - Config file defining release targets where builds can be published.
+releasers.conf - Config file defining release targets where builds can be 
+published.
 
 SYNOPSIS
 --------
@@ -14,50 +15,86 @@ None
 
 DESCRIPTION
 -----------
-Tito allows projects to define their own release targets, which can specify the exact releaser implementation to use (potentially a custom one), and any arguments it may need for a specific type of build.
+Tito allows projects to define their own release targets, which can specify 
+the exact releaser implementation to use (potentially a custom one), and any 
+arguments it may need for a specific type of build.
 
 
 RELEASERS
 ---------
 
-Tito includes several releaser implementations that can be used in releasers.conf. Additionally you may define a lib_dir in your tito.props globalconfig section, and place your own custom implementation of a releaser there.
+Tito includes several releaser implementations that can be used in 
+releasers.conf. Additionally you may define a lib_dir in your tito.props 
+globalconfig section, and place your own custom implementation of a releaser 
+there.
 
-Specify "builder.test = 1" in your releasers.conf target to enable --test builds. (uses the latest git HEAD rather than the latest tagged package) This can be useful for automating the publishing of a nightly build, which you would not want to continually have to tag.
+Specify "builder.test = 1" in your releasers.conf target to enable --test 
+builds. (uses the latest git HEAD rather than the latest tagged package) This 
+can be useful for automating the publishing of a nightly build, which you 
+would not want to continually have to tag.
 
 tito.release.YumRepoReleaser::
-Releaser which will build your packages, rsync down an existing yum repository, place your packages in it, regenerate the yum repodata, and rsync the yum repository back up.
+Releaser which will build your packages, rsync down an existing yum repository,
+place your packages in it, regenerate the yum repodata, and rsync the yum 
+repository back up.
 +
-Specify "filetypes = srpm" if you want to build a source rpm instead of a regular rpm.
+Specify "filetypes = srpm" if you want to build a source rpm instead of a 
+regular rpm.
 +
-Specify "createrepo_command = createrepo -s sha1" if you are building on a recent distro and are working with yum repositories for rhel5.
+Specify "createrepo_command = createrepo -s sha1" if you are building on a 
+recent distro and are working with yum repositories for rhel5.
 +
 You can use environment variable RSYNC_USERNAME to override rsync username.
 
 tito.release.RsyncReleaser::
 Releaser which will build your packages, and rsync up to a remote repository.
 +
-Specify "filetypes = rpm srpm tgz" to choose what type of packages will be uploaded.
+Specify "filetypes = rpm srpm tgz" to choose what type of packages will be 
+uploaded.
 +
 You can use environment variable RSYNC_USERNAME to override rsync username.
 +
 Specify "scl = COLLECTION" to build into Software Collection.
 +
-Variable "rsync_args" can specify addiontal argument passed to rsync. Default is "-rlvz".
+Variable "rsync_args" can specify addiontal argument passed to rsync. Default 
+is "-rlvz".
 
 tito.release.FedoraGitReleaser::
-Releaser which will checkout your project in Fedora git using fedpkg. Sources are then synced to the first branch your releaser lists. After this tito will git merge the first branch into all other listed branches, triggering builds in each.
+Releaser which will checkout your project in Fedora git using fedpkg. Sources 
+are then synced to the first branch your releaser lists. After this tito will 
+git merge the first branch into all other listed branches, triggering builds 
+in each.
 +
-WARNING: Highly experimental, very prone to failure if merging master into your branches is likely to cause a conflict. You will need to cleanup manually if this occurs.
+WARNING: Highly experimental, very prone to failure if merging master into 
+your branches is likely to cause a conflict. You will need to cleanup manually 
+if this occurs.
 +
  [fedora-git]
  releaser = tito.release.FedoraGitReleaser
  branches = master el5 el6 f14 f15 f16
++
+If you would like to build (ie - koji) against a different target than what is 
+default for the FedoraGit/DistGit branch currently being worked on it can be
+done like the following example.
++
+NOTE: The formatting of build_targets in the following example is 
+git_branch:koji_build_target and the following custom build targets are just 
+place holders for the example and aren't likely to exist in Fedora's koji
++
+ [fedora-git-custom-target]
+ releaser = tito.release.FedoraGitReleaser
+ branches = master el6 f19
+ build_targets = master:custom-target el6:el6-custom-target f19:f19-custom-target
++
 
 tito.release.DistGitReleaser::
 Same as FedoraGitReleaser, but use rhpkg instead of fedpkg.
 
 tito.release.CvsReleaser::
-Releaser which will submit builds through CVS build systems. (no longer useful for Fedora) The CVS module is checked out, sources, spec file, and patches are synced and committed, the release is tagged (make tag), and then submitted to the build system. (make build)
+Releaser which will submit builds through CVS build systems. (no longer useful 
+for Fedora) The CVS module is checked out, sources, spec file, and patches are 
+synced and committed, the release is tagged (make tag), and then submitted to 
+the build system. (make build)
 +
  [cvs]
  releaser = tito.release.CvsReleaser
@@ -65,30 +102,42 @@ Releaser which will submit builds through CVS build systems. (no longer useful f
  branches = BRANCH1 BRANCH2
 
 tito.release.KojiReleaser::
-Releaser which create src.rpm and submit them into Koji. Can submit more then one build at once.
+Releaser which create src.rpm and submit them into Koji. Can submit more then 
+one build at once.
 +
-NOTE: This is targeted for private instances of Koji. You can not submit regular build into Fedora Koji using this releaser, because Fedora Koji do not allow builds from src.rpm - for building into Fedora see FedoraGitReleaser above.
+NOTE: This is targeted for private instances of Koji. You can not submit 
+regular build into Fedora Koji using this releaser, because Fedora Koji do not 
+allow builds from src.rpm - for building into Fedora see FedoraGitReleaser 
+above.
 +
   [koji]
   releaser = tito.release.KojiReleaser
   autobuild_tags = my-koji-tag-rhel6 my-koji-tag-fedora18
 +
-In this example, releaser will create src.rpm according the definition of [my-koji-tag-rhel6] in tito.props. You usually want to set up there at least disttag. See KOJI section in tito.props(5).
+In this example, releaser will create src.rpm according the definition of 
+[my-koji-tag-rhel6] in tito.props. You usually want to set up there at least 
+disttag. See KOJI section in tito.props(5).
 +
-If --scratch option or SCRATCH environment variable is set, package is build as scratch in Koji.
+If --scratch option or SCRATCH environment variable is set, package is build 
+as scratch in Koji.
 +
-You can specify KOJI_OPTIONS in titorc(5) and it is passed to koji command as option. Usually you want to specify at least --config option.
+You can specify KOJI_OPTIONS in titorc(5) and it is passed to koji command as 
+option. Usually you want to specify at least --config option.
 +
 Variable autobuild_tags is required for KojiReleaser.
 
 tito.release.KojiGitReleaser::
-Build into Koji through dist-git. It behaves as KojiReleaser. Only difference is that src.rpm is not passed to Koji. Instead is sent to koji git hash from which Koji should build package.
+Build into Koji through dist-git. It behaves as KojiReleaser. Only difference 
+is that src.rpm is not passed to Koji. Instead is sent to koji git hash from 
+which Koji should build package.
 +
 Note: This feature is not in upstream Koji (although is submited for long time).
 +
-Please do not confuse with FedoraGitReleaser. KojiGitReleaser is intended for private instances of Koji.
+Please do not confuse with FedoraGitReleaser. KojiGitReleaser is intended for 
+private instances of Koji.
 +
-You need to specify git_url, which specify url of git repository. This url needs to be reachable from Koji.
+You need to specify git_url, which specify url of git repository. This url 
+needs to be reachable from Koji.
 
 EXAMPLE
 -------

--- a/tito.8.asciidoc
+++ b/tito.8.asciidoc
@@ -165,13 +165,15 @@ Pass 'OPTIONS' to rpmbuild.
 
 --builder='BUILDER'::
 Override the normal builder by specifying a full class
-path or one of the pre-configured shortcuts. Only useful if you need to override the default builder for some purpose, such as testing a build via mock.
+path or one of the pre-configured shortcuts. Only useful if you need to 
+override the default builder for some purpose, such as testing a build via mock.
 
 --builder-arg='BUILDER_ARGS'::
 Custom arguments specific to a particular builder. (key=value)
 
 --scl='COLLECTION'::
-Build package for software collection. This is mostly usefull for building src.rpm, because for rpm you want to define this option for specific tag in tito.props
+Build package for software collection. This is mostly usefull for building 
+src.rpm, because for rpm you want to define this option for specific tag in tito.props
 
 
 `tito release [options] TARGETS`

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -21,7 +21,10 @@ Project settings can be stored in files:
 
 `GITROOT/SOME/PACKAGE/tito.props`
 
-The global rel-eng/tito.props is generally where settings are defined. For some multi-project git repositories, individual packages can override these settings by placing a tito.props in the project directory. (i.e. same location as it's .spec file)
+The global rel-eng/tito.props is generally where settings are defined. For 
+some multi-project git repositories, individual packages can override these 
+settings by placing a tito.props in the project directory. (i.e. same location 
+as it's .spec file)
 
 
 SECTIONS
@@ -36,14 +39,20 @@ default builder and tagger for you project. You can use following variables:
 
 default_builder::
 The fully qualified Builder class implementation to use.
-You can either specify builders shipped with tito(5) (see BUILDERS section below), or a custom builder located within the directory your `lib_dir` option points to.
+You can either specify builders shipped with tito(5) (see BUILDERS section 
+below), or a custom builder located within the directory your `lib_dir` option 
+points to.
 
 default_tagger::
 The fully qualified Tagger class implementation to use.
-You can either specify builders shipped with tito(5) (see TAGGERS section below), or a custom builder located within the directory your `lib_dir` option points to.
+You can either specify builders shipped with tito(5) (see TAGGERS section 
+below), or a custom builder located within the directory your `lib_dir` option 
+points to.
 
 lib_dir::
-Optional property defining a directory to be added to the Python path when executing tito. Allows you to store custom implementations of Builder, Tagger, and Releaser.
+Optional property defining a directory to be added to the Python path when 
+executing tito. Allows you to store custom implementations of Builder, Tagger, 
+and Releaser.
 
 changelog_format::
 This option is used to control the formatting of entries when
@@ -61,7 +70,10 @@ If set to 0, it will not remove from cherry picked commits the part "(cherry
 picked from commit ...)"
 
 tag_suffix::
-An optional specification of a suffix to append to all tags created by tito for this repo. Can be useful for situations where one git repository is inheriting from another, but tags are created in both. The suffix will be an indicator as to which repo the tag originated in. (i.e. tag_suffix = -mysuffix)
+An optional specification of a suffix to append to all tags created by tito 
+for this repo. Can be useful for situations where one git repository is 
+inheriting from another, but tags are created in both. The suffix will be an 
+indicator as to which repo the tag originated in. (i.e. tag_suffix = -mysuffix)
 
 
 KOJI
@@ -102,10 +114,12 @@ If tito is older then specified version, it will refuse to continue.
 BUILDCONFIG
 -----------
 builder::
-This option is used in package specific tito.props only, and allows that project to override the default_builder defined in rel-eng/tito.props.
+This option is used in package specific tito.props only, and allows that 
+project to override the default_builder defined in rel-eng/tito.props.
 
 tagger::
-This option is used in package specific tito.props only, and allows that project to override the default_tagger defined in rel-eng/tito.props.
+This option is used in package specific tito.props only, and allows that 
+project to override the default_tagger defined in rel-eng/tito.props.
 
 
 TAGCONFIG


### PR DESCRIPTION
Did some "clean up" (my opinion only) to remove line wrap over 80 chars where possible. Added docs for build_targets which is located https://github.com/maxamillion/tito/pull/new/dgoodwin:master...maxamillion:docs#L0R76

If in the event the "clean up" is preferred to be removed and leave the line wrapping in there I will happily modify this commit to only include the build_targets addition.
