### PR TITLE
add newline to sys.stderr.write

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -246,7 +246,7 @@ def tag_exists_remotely(tag):
     try:
         repo_url = get_git_repo_url()
     except:
-        sys.stderr.write('Warning: remote.origin do not exist. Assuming --offline, for remote tag checking.')
+        sys.stderr.write('Warning: remote.origin do not exist. Assuming --offline, for remote tag checking.\n')
         return False
     sha1 = get_remote_tag_sha1(tag)
     debug("sha1 = %s" % sha1)
@@ -322,7 +322,7 @@ def check_tag_exists(tag, offline=False):
     try:
         repo_url = get_git_repo_url()
     except:
-        sys.stderr.write('Warning: remote.origin do not exist. Assuming --offline, for remote tag checking.')
+        sys.stderr.write('Warning: remote.origin do not exist. Assuming --offline, for remote tag checking.\n')
         return
     upstream_tag_sha1 = get_remote_tag_sha1(tag)
     if upstream_tag_sha1 == "":

--- a/src/tito/release.py
+++ b/src/tito/release.py
@@ -659,9 +659,9 @@ class FedoraGitReleaser(Releaser):
             if "already been built" in output:
                 print("Build has been submitted previously, continuing...")
             else:
-                sys.stderr.write("ERROR: Unable to submit build.")
-                sys.stderr.write("  Status code: %s" % status)
-                sys.stderr.write("  Output: %s" % output)
+                sys.stderr.write("ERROR: Unable to submit build.\n")
+                sys.stderr.write("  Status code: %s\n" % status)
+                sys.stderr.write("  Output: %s\n" % output)
                 sys.exit(1)
 
     def _git_upload_sources(self, project_checkout):

--- a/src/tito/tagger.py
+++ b/src/tito/tagger.py
@@ -513,12 +513,12 @@ class VersionTagger(ConfigObject):
         try:
             name = run_command('git config --get user.name')
         except:
-            sys.stderr.write('Warning: user.name in ~/.gitconfig not set.')
+            sys.stderr.write('Warning: user.name in ~/.gitconfig not set.\n')
             name = 'Unknown name'
         try:
             email = run_command('git config --get user.email')
         except:
-            sys.stderr.write('Warning: user.email in ~/.gitconfig not set.')
+            sys.stderr.write('Warning: user.email in ~/.gitconfig not set.\n')
             email = None
         return (name, email)
 


### PR DESCRIPTION
sys.stderr.write does not add automatically \n as print does.

Addressing:
Warning: remote.origin do not exist. Assuming --offline, for remote tag checking.Building package [osc-0.132.4-4]

And I checked all sys.stderr.write() occurence in code as well.
