### PR TITLE
MANIFEST.in: include README.mkd and asciidoc files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,8 @@ include AUTHORS
 include LICENSE
 include MANIFEST.in
 include COPYING
+include README.mkd
+include *.5
+include *.asciidoc
 recursive-include bin *.*
 recursive-include test *.*


### PR DESCRIPTION
When `python setup.py sdist` is run to generate a source tarball for
`rpmbuild`, it currently doesn't include some key files which causes
`rpmbuild` to fail. So add these to `MANIFEST.in`.
