### PR TITLE
Improved docs for [version_template] section of tito.props

### DIFF
--- a/src/tito/tagger.py
+++ b/src/tito/tagger.py
@@ -558,13 +558,14 @@ class VersionTagger(ConfigObject):
 
     def _version_file_template (self):
         """
-        "$version_name = $version"
-        or provide a configuration in tito.props to a file that is a
+        provide a configuration in tito.props to a file that is a
         python string.Template conforming blob, like
             [version]
             template_file = ./rel-eng/templates/my_java_properties
 
-        see also, http://docs.python.org/2/library/string.html#template-strings
+        variables defined inside the template are $version and $release
+
+        see also http://docs.python.org/2/library/string.html#template-strings
         """
         if self.config.has_option("version_template", "template_file"):
             f = open(os.path.join(self.git_root,
@@ -577,8 +578,7 @@ class VersionTagger(ConfigObject):
 
     def _version_file_path (self):
         """
-        standard ${project_name}-version.conf
-        or provide a configuration in tito.props, like
+        provide a version file to write in tito.props, like
             [version]
             file = ./foo.rb
         """
@@ -628,5 +628,3 @@ class ForceVersionTagger(VersionTagger):
         self._update_changelog(new_version)
         self._update_setup_py(new_version)
         self._update_package_metadata(new_version)
-
-

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -111,7 +111,7 @@ VERSION_TEMPLATE
 Allows the user to write out a template file containing version and/or release and add it to git during the tagging process.
 
 template_file::
-Path to a file conforming to a Python string template. Path is relative to root of the entire git checkout, as this is likely to be stored in the top level rel-eng directory.
+Path to a file conforming to a Python string.Template, as described at http://docs.python.org/2/library/string.html#template-strings. Path is relative to root of the entire git checkout, as this is likely to be stored in the top level rel-eng directory.  The variables $version and $release are available inside the template.
 
 destination_file::
 Specifies a file to write, relative to the directory for the package being tagged.


### PR DESCRIPTION
I had to RTFS to figure out what was actually meant by "conforming to a Python string template."  This improves both the tito.props(5) man page and the docstrings in the source make it clearer how the version template works.
