### PR TITLE
Change package-specific config message to debug

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -165,7 +165,7 @@ class ConfigLoader(object):
                     self.tag)
                 return
 
-        print("Unable to locate package specific config for this package.")
+        debug("Unable to locate package specific config for this package.")
 
 
 def read_user_config():


### PR DESCRIPTION
When this feature isn't used, the output of tito seems unnecessarily verbose.
