### PR TITLE
Cleanup releasers + builders when interrupted

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -598,10 +598,15 @@ class ReleaseModule(BaseCliModule):
                 auto_accept=self.options.auto_accept,
                 **kwargs)
 
-            releaser.release(dry_run=self.options.dry_run,
-                    no_build=self.options.no_build,
-                    scratch=self.options.scratch)
-            releaser.cleanup()
+            try:
+                try:
+                    releaser.release(dry_run=self.options.dry_run,
+                            no_build=self.options.no_build,
+                            scratch=self.options.scratch)
+                except KeyboardInterrupt:
+                    print("Interrupted, cleaning up...")
+            finally:
+                releaser.cleanup()
 
             # Make sure we go back to where we started, otherwise multiple
             # builders gets very confused:

--- a/src/tito/release/main.py
+++ b/src/tito/release/main.py
@@ -163,6 +163,9 @@ class Releaser(ConfigObject):
         if not self.no_cleanup:
             debug("Cleaning up [%s]" % self.working_dir)
             run_command("rm -rf %s" % self.working_dir)
+
+            if self.builder:
+                self.builder.cleanup()
         else:
             print("WARNING: leaving %s (--no-cleanup)" % self.working_dir)
 


### PR DESCRIPTION
When receiving a keyboard interrupt (SIGINT) the releaser cleanup is now called, and the builder is in turn cleaned up.

This is particularly important for the GitAnnexBuilder combined with the Copr or Koji builders, otherwise the annexed files are left in an "unlocked" state if you hit ctrl+c while the koji/copr task runs.
