### PR TITLE
spec: remove dependency on GitPython

### DIFF
--- a/tito.spec
+++ b/tito.spec
@@ -20,7 +20,6 @@ BuildRequires: libxslt
 Requires: python-setuptools
 Requires: rpm-build
 Requires: rpmlint
-Requires: GitPython >= 0.2.0
 Requires: fedpkg
 Requires: fedora-cert
 Requires: fedora-packager


### PR DESCRIPTION
3ae15969237b8cd292fdd7601e8ed74b92971193 removed GitPython
from the source, but forgot to remove the dependency from
the rpm spec file.
