### PR TITLE
propagate docs to docker public registry

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -1,6 +1,9 @@
 Hacking
 =======
 
+This is the developer documentation for
+https://github.com/dgoodwin/tito
+
 Python versions
 ---------------
 

--- a/hacking/titotest-centos-5.9/README.md
+++ b/hacking/titotest-centos-5.9/README.md
@@ -1,0 +1,1 @@
+../../HACKING.mkd

--- a/hacking/titotest-centos-6.4/README.md
+++ b/hacking/titotest-centos-6.4/README.md
@@ -1,0 +1,1 @@
+../../HACKING.mkd

--- a/hacking/titotest-fedora-20/README.md
+++ b/hacking/titotest-fedora-20/README.md
@@ -1,0 +1,1 @@
+../../HACKING.mkd


### PR DESCRIPTION
Add URL of upstream tito repo to HACKING, then
symlink HACKING as README.md in each Dockerfile dir.

Why?

If a README.md exists in same dir as Dockerfile (incl. symlink),
and it's set up as a
[trusted build](https://index.docker.io/help/docs/#trustedbuilds),
then index.docker.io automatically shows the readme on the info
page of the trusted build.
