### PR TITLE
Add 'scl' builder option for software collection name

### DIFF
--- a/releasers.conf.5.asciidoc
+++ b/releasers.conf.5.asciidoc
@@ -54,7 +54,8 @@ uploaded.
 +
 You can use environment variable RSYNC_USERNAME to override rsync username.
 +
-Specify "scl = COLLECTION" to build into Software Collection.
+Specify "scl = COLLECTION" to build into Software Collection.  Deprecated,
+prefer "builder.scl = COLLECTION" instead.
 +
 Variable "rsync_args" can specify addiontal argument passed to rsync. Default
 is "-rlvz".

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -63,8 +63,8 @@ class BuilderBase(object):
         self.offline = self._get_optional_arg(kwargs, 'offline', False)
         self.auto_install = self._get_optional_arg(kwargs, 'auto_install',
                 False)
-        self.scl = self._get_optional_arg(kwargs,
-                'scl', '')
+        self.scl = self._get_optional_arg(args, 'scl', None) or \
+                self._get_optional_arg(kwargs, 'scl', '')
 
         self.rpmbuild_options = self._get_optional_arg(kwargs,
                 'rpmbuild_options', None)

--- a/src/tito/release/main.py
+++ b/src/tito/release/main.py
@@ -258,7 +258,9 @@ class RsyncReleaser(Releaser):
                 builder_class=self.releaser_config.get(self.target, 'builder'),
                 offline=self.offline)
         if self.releaser_config.has_option(self.target, "scl"):
-                self.builder.scl = self.releaser_config.get(self.target, "scl")
+            sys.stderr.write("WARNING: please rename 'scl' to "
+                "'builder.scl' in releasers.conf\n")
+            self.builder.scl = self.releaser_config.get(self.target, "scl")
 
     def release(self, dry_run=False, no_build=False, scratch=False):
         self.dry_run = dry_run

--- a/test/functional/builder_tests.py
+++ b/test/functional/builder_tests.py
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2008-2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+import os
+import tempfile
+from tito.builder import Builder
+from tito.common import *
+from functional.fixture import TitoGitTestFixture, tito
+
+PKG_NAME = "titotestpkg"
+
+
+class BuilderTests(TitoGitTestFixture):
+
+    def setUp(self):
+        TitoGitTestFixture.setUp(self)
+        os.chdir(self.repo_dir)
+
+        self.config = RawConfigParser()
+        self.output_dir = tempfile.mkdtemp("-titotestoutput")
+
+    def test_scl_from_options(self):
+        self.create_project(PKG_NAME)
+        builder = Builder(PKG_NAME, None, self.output_dir,
+            self.config, {}, {'scl': 'ruby193'}, **{'offline': True})
+        self.assertEqual('ruby193', builder.scl)
+
+    def test_scl_from_kwargs(self):
+        self.create_project(PKG_NAME)
+        builder = Builder(PKG_NAME, None, self.output_dir,
+            self.config, {}, {}, **{'offline': True, 'scl': 'ruby193'})
+        self.assertEqual('ruby193', builder.scl)


### PR DESCRIPTION
With a general 'scl' builder option, a software collection name can be
specified irrespective of the releaser used.  RsyncReleaser's own 'scl'
option has been deprecated in favour of using 'builder.scl' in
releasers.conf.

---

Is there somewhere good to document (generic) builder options?  I can't really see much now - maybe I should add a section to the top of doc/builders.mkd?
