### PR TITLE
Allow builder to run in test mode on untagged project

### DIFF
--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -32,7 +32,7 @@ from tito.common import (debug, error_out, run_command,
         get_spec_version_and_release, replace_version,
         tag_exists_locally, tag_exists_remotely, head_points_to_tag, undo_tag,
         increase_version, reset_release, increase_zstream,
-        BUILDCONFIG_SECTION)
+        BUILDCONFIG_SECTION, get_relative_project_dir_cwd)
 from tito.compat import *
 from tito.exception import TitoException
 from tito.config_object import ConfigObject
@@ -55,7 +55,7 @@ class VersionTagger(ConfigObject):
         self.spec_file_name = find_spec_file()
         self.project_name = get_project_name(tag=None)
 
-        self.relative_project_dir = self._get_relative_project_dir(
+        self.relative_project_dir = get_relative_project_dir_cwd(
             self.git_root)  # i.e. java/
 
         self.spec_file = os.path.join(self.full_project_dir,
@@ -324,21 +324,6 @@ class VersionTagger(ConfigObject):
         buf.close()
 
         run_command("git add %s" % setup_file)
-
-    def _get_relative_project_dir(self, git_root):
-        """
-        Returns the patch to the project we're working with relative to the
-        git root.
-
-        *MUST* be called before doing any os.cwd().
-
-        i.e. java/, satellite/install/Spacewalk-setup/, etc.
-        """
-        current_dir = os.getcwd()
-        relative = current_dir[len(git_root) + 1:] + "/"
-        if relative == "/":
-            relative = "./"
-        return relative
 
     def _bump_version(self, release=False, zstream=False, force=False):
         """

--- a/test/functional/builder_tests.py
+++ b/test/functional/builder_tests.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2008-2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+
+import os
+import tempfile
+from os.path import join
+from tito.builder import Builder
+from tito.common import *
+from functional.fixture import TitoGitTestFixture, tito
+
+PKG_NAME = "titotestpkg"
+
+
+class BuilderTests(TitoGitTestFixture):
+
+    def setUp(self):
+        TitoGitTestFixture.setUp(self)
+        os.chdir(self.repo_dir)
+
+        self.config = RawConfigParser()
+        self.output_dir = tempfile.mkdtemp("-titotestoutput")
+
+    def test_untagged_test_version(self):
+        self.create_project(PKG_NAME, tag=False)
+        self.assertEqual("", run_command("git tag -l").strip())
+
+        builder = Builder(PKG_NAME, None, self.output_dir,
+            self.config, {}, {}, **{'offline': True, 'test': True})
+        self.assertEqual('0.0.1-1', builder.build_version)
+
+    def test_untagged_test_build(self):
+        self.create_project(PKG_NAME, tag=False)
+        self.assertEqual("", run_command("git tag -l").strip())
+        tito('build --srpm --test')

--- a/test/functional/fixture.py
+++ b/test/functional/fixture.py
@@ -152,7 +152,7 @@ class TitoGitTestFixture(unittest.TestCase):
         config.write(configfile)
         configfile.close()
 
-    def create_project(self, pkg_name, pkg_dir=''):
+    def create_project(self, pkg_name, pkg_dir='', tag=True):
         """
         Create a test project at the given location, assumed to be within
         our test repo, but possibly within a sub-directory.
@@ -186,4 +186,5 @@ class TitoGitTestFixture(unittest.TestCase):
         run_command('git add %s' % ' '.join(files))
         run_command("git commit -m 'initial commit'")
 
-        tito('tag --keep-version --debug --accept-auto-changelog')
+        if tag:
+            tito('tag --keep-version --debug --accept-auto-changelog')


### PR DESCRIPTION
Particularly useful when creating new projects and wanting to avoid
creating an initial tag, this allows `tito build --test --srpm` etc
to run without any tag.
