### PR TITLE
avoid syntax error on el5

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -13,7 +13,6 @@
 """
 Common operations.
 """
-from __future__ import print_function
 import os
 import re
 import sys


### PR DESCRIPTION
run_command_print originally used trailing comma to suppress newline,
but python3 needs a named argument (`end=`) [1].

38446dca added 'from future...' to support python3's `end=` argument,
but the import causes error on el5:

```
SyntaxError (future feature print_function is not defined
```

6b9787e2 introduced an approach to strip newlines compatible
with both el5's python2 and fedora 20's python3.

This means we don't need the future import any more, and
we can safely remove it to restore el5 compatibility.

[1] https://docs.python.org/3.0/whatsnew/3.0.html#print-is-a-function
