### PR TITLE
Remove excess whitespace on EL6 and duplicate SRPM output

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -201,7 +201,6 @@ class BuilderBase(object):
                 rpmbuild_options, self._get_rpmbuild_dir_options(),
                 define_dist, self.spec_file))
         output = run_command_print(cmd)
-        print(output)
         self.srpm_location = find_wrote_in_rpmbuild_output(output)[0]
         self.artifacts.append(self.srpm_location)
 

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -240,7 +240,8 @@ def run_subprocess(p):
     while(True):
         retcode = p.poll()
         line = p.stdout.readline()
-        yield line
+        if len(line) > 0:
+            yield line
         if(retcode is not None):
             break
 

--- a/test/unit/common-tests.py
+++ b/test/unit/common-tests.py
@@ -102,6 +102,9 @@ class CommonTests(unittest.TestCase):
         self.assertEquals(0, compare_version("1.0", "1"))
         self.assertEquals(0, compare_version("1.0.2.0", "1.0.2"))
 
+    def test_run_command_print(self):
+        self.assertEquals('\n', run_command_print("sleep 0.1"))
+
 
 class VersionMathTest(unittest.TestCase):
     def test_increase_version_minor(self):


### PR DESCRIPTION
On EL6, if you do a build then you can get a lot of whitespace in the output - particularly on a slower VM I think, as it doesn't happen often under the EL6 Docker image.  The SRPM output was also duplicated due to use of run_command_print.
