### PR TITLE
Fix bugs in git-annex cleanup method

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -1017,7 +1017,7 @@ class GitAnnexBuilder(NoTgzBuilder):
         os.chdir(old_cwd)
 
     def cleanup(self):
-        if _lock_force_supported(_get_annex_version()):
+        if self._lock_force_supported(self._get_annex_version()):
             run_command("git-annex lock --force")
         else:
             run_command("git-annex lock")
@@ -1027,7 +1027,7 @@ class GitAnnexBuilder(NoTgzBuilder):
         # git-annex needs to support --force when locking files.
         ga_version = run_command('git-annex version').split('\n')
         if ga_version[0].startswith('git-annex version'):
-            ga_version[0].split()[-1]
+            return ga_version[0].split()[-1]
         else:
             return 0
 

--- a/test/functional/build_gitannex_tests.py
+++ b/test/functional/build_gitannex_tests.py
@@ -87,6 +87,7 @@ class GitAnnexBuilderTests(TitoGitTestFixture):
             "extsrc-0.0.2-1.*src.rpm"))))
         self.assertEquals(1, len(glob.glob(join(self.output_dir, 'noarch',
             "extsrc-0.0.2-1.*.noarch.rpm"))))
+        builder.cleanup()
 
     def test_lock_force_supported(self):
         tito('tag --debug --accept-auto-changelog')


### PR DESCRIPTION
Note to self: this isn't Ruby.

Seems the test wasn't ever hitting cleanup(), so this should exercise it properly across all platforms.
