### PR TITLE
add build dependency for el5 and new functional tests

### DIFF
--- a/hacking/titotest-centos-5.9/Dockerfile
+++ b/hacking/titotest-centos-5.9/Dockerfile
@@ -9,6 +9,7 @@ RUN rpm -Uvh http://mirror.es.its.nyu.edu/epel/5/x86_64/epel-release-5-4.noarch.
 RUN yum -y install git rpm-build \
     python-devel python-nose python-setuptools python-pep8 \
     python-pip \
+    docbook-style-xsl \
     libxslt asciidoc tar createrepo which
 
 RUN pip-python install mock --upgrade

--- a/hacking/titotest-centos-5.9/README.md
+++ b/hacking/titotest-centos-5.9/README.md
@@ -1,1 +1,1 @@
-../../HACKING.mkd
+../../HACKING

--- a/hacking/titotest-centos-6.4/README.md
+++ b/hacking/titotest-centos-6.4/README.md
@@ -1,1 +1,1 @@
-../../HACKING.mkd
+../../HACKING

--- a/hacking/titotest-fedora-20/Dockerfile
+++ b/hacking/titotest-fedora-20/Dockerfile
@@ -4,8 +4,12 @@ FROM mattdm/fedora:f20
 # http://jumanjiman.github.io/
 MAINTAINER Paul Morgan <jumanjiman@gmail.com>
 
+# F20 needs updates to resolve conflict with asciidoc.
+RUN yum -y update; yum clean all
+
 # Install dependencies.
 RUN yum -y install git rpm-build libxslt tar \
+    asciidoc \
     python-devel python-nose python-setuptools python-pep8 \
     python-mock \
     python3-devel python3-nose python3-setuptools python3-pep8 rpm-python3 python3-mock \

--- a/hacking/titotest-fedora-20/README.md
+++ b/hacking/titotest-fedora-20/README.md
@@ -1,1 +1,1 @@
-../../HACKING.mkd
+../../HACKING

--- a/test/functional/build_tito_tests.py
+++ b/test/functional/build_tito_tests.py
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2008-2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+'''
+Functional tests to build tito with tito.
+This can catch indirect omissions within tito itself.
+'''
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from functional.fixture import tito
+from glob import glob
+from os.path import join
+
+
+class BuildTitoTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        'Run tito build before _all_ tests in this class.'
+        self.output_dir = tempfile.mkdtemp("-titotestoutput")
+        os.chdir(os.path.abspath(join(__file__, '..', '..', '..')))
+        self.artifacts = tito(
+            'build --rpm --test --output=%s --offline --no-cleanup --debug' %
+            self.output_dir
+        )
+
+    @classmethod
+    def tearDownClass(self):
+        'Clean up after _all_ tests in this class unless any test fails.'
+        shutil.rmtree(self.output_dir)
+
+    def test_build_tito(self):
+        'Tito creates three artifacts'
+        self.assertEqual(3, len(self.artifacts))
+
+    def test_find_srpm(self):
+        'One artifact is an SRPM'
+        srpms = glob(join(self.output_dir, 'tito-*src.rpm'))
+        self.assertEqual(1, len(srpms))
+
+    def test_find_rpm(self):
+        'One artifact is a noarch RPM'
+        rpms = glob(join(self.output_dir, 'noarch', 'tito-*noarch.rpm'))
+        self.assertEqual(1, len(rpms))
+
+    def test_find_tgz(self):
+        'One artifact is a tarball'
+        tgzs = glob(join(self.output_dir, 'tito-*tar.gz'))
+        self.assertEqual(1, len(tgzs))

--- a/tito.spec
+++ b/tito.spec
@@ -15,6 +15,7 @@ BuildArch: noarch
 BuildRequires: python-devel
 BuildRequires: python-setuptools
 BuildRequires: asciidoc
+BuildRequires: docbook-style-xsl
 BuildRequires: libxslt
 
 Requires: python-setuptools


### PR DESCRIPTION
- asciidoc indirectly requires docbook-style-xsl on el6 and f20,
  but not on el5. Resolve failure to build tito with tito on el5:
  "I/O error : Attempt to load network entity"
- Resolve "egg missing file" on el5 due to busted symlinks
  from 20c4f1b7c0942.
- Add functional test to build tito with itself in order to
  catch problems like the ones above.

Closes https://github.com/dgoodwin/tito/issues/133
