### PR TITLE
Python3

### DIFF
--- a/tito.spec
+++ b/tito.spec
@@ -71,10 +71,8 @@ rm -f $RPM_BUILD_ROOT%{python_sitelib}/*egg-info/requires.txt
 # manpages
 %{__mkdir_p} %{buildroot}%{_mandir}/man5
 %{__mkdir_p} %{buildroot}%{_mandir}/man8
-%{__gzip} -c titorc.5 > %{buildroot}/%{_mandir}/man5/titorc.5.gz
-%{__gzip} -c tito.8 > %{buildroot}/%{_mandir}/man8/tito.8.gz
-%{__gzip} -c tito.props.5 > %{buildroot}/%{_mandir}/man5/tito.props.5.gz
-%{__gzip} -c releasers.conf.5 > %{buildroot}/%{_mandir}/man5/releasers.conf.5.gz
+cp -a titorc.5 tito.props.5 releasers.conf.5 %{buildroot}/%{_mandir}/man5/
+cp -a tito.8 %{buildroot}/%{_mandir}/man8/
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -84,10 +82,10 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %doc README.mkd AUTHORS COPYING
 %doc doc/*
-%doc %{_mandir}/man5/titorc.5.gz
-%doc %{_mandir}/man5/tito.props.5.gz
-%doc %{_mandir}/man5/releasers.conf.5.gz
-%doc %{_mandir}/man8/tito.8.gz
+%doc %{_mandir}/man5/titorc.5*
+%doc %{_mandir}/man5/tito.props.5*
+%doc %{_mandir}/man5/releasers.conf.5*
+%doc %{_mandir}/man8/tito.8*
 %{_bindir}/tito
 %{_bindir}/tar-fixup-stamp-comment.pl
 %{_bindir}/test-setup-specfile.pl


### PR DESCRIPTION
Use python3 on Fedora22+
and do not compress man pages (because rpmbuild do that automatically).