### PR TITLE
Help new packagers find tools related to tito

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -26,6 +26,14 @@ Tito offers the following features:
  - Manage all of the above for a git repository with many disjoint packages
    within it.
 
+RELATED PROJECTS
+================
+
+* `mockchain` from the  (http://fedoraproject.org/wiki/Projects/Mock)[mock project])
+* `mock`'s built-in SCM support in `mock-scm`
+* Fedora's [Koji](http://koji.fedoraproject.org/koji/) build engine and [fedpkg](https://fedorahosted.org/fedpkg/) tools
+* The [OpenSUSE Build Service](https://build.opensuse.org/).
+
 INSTALL
 =======
 


### PR DESCRIPTION
tito is an easily discovered tool when looking for information on rpm packaging, especially SCM integration.

There are now some useful related tools, like mock's SCM integration, mockchain, Koji, fedpkg, etc that are not especially easily discovered by new packagers. Making these more visible by documenting them in tito's README would be a help to new packagers.