### PR TITLE
Allow override of rpmbuild_options from builder arguments

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -70,10 +70,8 @@ class BuilderBase(object):
         self.scl = self._get_optional_arg(args, 'scl', None) or \
                 self._get_optional_arg(kwargs, 'scl', '')
 
-        self.rpmbuild_options = self._get_optional_arg(kwargs,
-                'rpmbuild_options', None)
-        if not self.rpmbuild_options:
-            self.rpmbuild_options = ''
+        self.rpmbuild_options = self._get_optional_arg(args, 'rpmbuild_options', None) or \
+                self._get_optional_arg(kwargs, 'rpmbuild_options', '')
 
         self.test = self._get_optional_arg(kwargs, 'test', False)
         # Allow a builder arg to override the test setting passed in, used by

--- a/test/functional/builder_tests.py
+++ b/test/functional/builder_tests.py
@@ -44,6 +44,24 @@ class BuilderTests(TitoGitTestFixture):
             self.config, {}, {}, **{'offline': True, 'scl': 'ruby193'})
         self.assertEqual('ruby193', builder.scl)
 
+    def test_rpmbuild_options_from_options(self):
+        self.create_project(PKG_NAME)
+        builder = Builder(PKG_NAME, None, self.output_dir,
+            self.config, {}, {'rpmbuild_options': '--define "foo bar"'}, **{'offline': True})
+        self.assertEqual('--define "foo bar"', builder.rpmbuild_options)
+
+    def test_rpmbuild_options_from_kwargs(self):
+        self.create_project(PKG_NAME)
+        builder = Builder(PKG_NAME, None, self.output_dir,
+            self.config, {}, {}, **{'offline': True, 'rpmbuild_options': '--define "foo bar"'})
+        self.assertEqual('--define "foo bar"', builder.rpmbuild_options)
+
+    def test_rpmbuild_options_missing(self):
+        self.create_project(PKG_NAME)
+        builder = Builder(PKG_NAME, None, self.output_dir,
+            self.config, {}, {}, **{'offline': True})
+        self.assertEqual('', builder.rpmbuild_options)
+
     def test_untagged_test_version(self):
         self.create_project(PKG_NAME, tag=False)
         self.assertEqual("", run_command("git tag -l").strip())


### PR DESCRIPTION
Instead of being a command line-only option, the string of extra rpmbuild
arguments can now be passed in via the general builder args mechanism, so it
can even be configured from releasers.conf.

Fixes #155