### PR TITLE
substitute /releng for /.tito #161

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -52,7 +52,7 @@ From your git repository:
 
     tito init
 
-This will create a top-level metadata directory called "rel-eng/" and commit it
+This will create a top-level metadata directory called ".tito/" and commit it
 to git. This directory will store tito's configuration and package metadata on
 a per branch basis. It will be filtered out when creating .tar.gz's.
 
@@ -70,7 +70,7 @@ root of the project at the top level of the git repository:
     docs/
     mypackage.spec
     README
-    rel-eng/
+    .tito/
     src/
     test/
 
@@ -78,7 +78,7 @@ For a multi-project git repository, packages can be defined in various
 sub-directories, provided they do not nest (i.e. walking up the tree, two spec
 files will never be encountered):
 
-    rel-eng/
+    .tito/
     package1/
         docs/
         mypackage.spec
@@ -113,7 +113,7 @@ By default if you omit --keep-version, tito will tag by bumping the rpm
 version. (i.e. we bump the Z in X.Y.Z. If you'd prefer to bump the package
 release instead (normally should just be used for changes to the spec file or
 patches applied within it), you can change the 'tagger' class in
-rel-eng/tito.props to ReleaseTagger. This will affect all packages in this git
+.tito/tito.props to ReleaseTagger. This will affect all packages in this git
 branch, if you'd prefer to do this on a per-package basis you can do so in a
 package specific tito.props. (see section below)
 
@@ -154,7 +154,7 @@ RELEASING PACKAGES
 
 Tito supports a mechanism where you can define multiple release targets.
 
-In rel-eng/releasers.conf, create a section like:
+In .tito/releasers.conf, create a section like:
 
     [yum-f15-x86_64]
     releaser = tito.release.YumRepoReleaser
@@ -207,7 +207,7 @@ history, and run:
     git reset --hard HEAD^1
 
 If your project is standalone (no remote reference you communicate with as
-authoritative) you may wish to set offline = "true" in rel-eng/tito.props under
+authoritative) you may wish to set offline = "true" in .tito/tito.props under
 the globalconfig section, so you do not need to specify --offline with each
 invocation.
 

--- a/doc/builders.mkd
+++ b/doc/builders.mkd
@@ -6,7 +6,7 @@ An unorthodox builder which can build packages for a git repo which does not act
 
 One strategy is currently included which parses a CLI argument to the build command which points to the source to use.
 
-Configuration for FetchBuilder in rel-eng/tito.props would look like:
+Configuration for FetchBuilder in .tito/tito.props would look like:
 
     [buildconfig]
     builder = tito.builder.FetchBuilder
@@ -18,7 +18,7 @@ Once configured a build can be run with:
 
   **tito build --rpm --arg=source=/home/username/extsrc-0.0.1.tar.gz**
 
-Note that this does not require a tito tag to have been run, and technically the rel-eng/tito.props does not have to be committed to the git repo. This builder can be used on a repository you do not control or do not wish to push tito configuration into.
+Note that this does not require a tito tag to have been run, and technically the .tito/tito.props does not have to be committed to the git repo. This builder can be used on a repository you do not control or do not wish to push tito configuration into.
 
 The ArgSourceStrategy has a simple mechanism where it will try to parse the version and release to build from the filename with a regular expression. If you need something more advanced, you can override any or all of this behaviour by implementing a custom strategy for the fetch builder. (see lib_dir in **man 5 tito.props**)
 
@@ -41,7 +41,7 @@ Add the spec file as normal, but add the tarball/source via git-annex instead:
     git annex add tito-0.4.18.tar.gz
     git commit -m "add tito 0.4.18"
 
-Edit rel-eng/tito.props to change the builder to the GitAnnexBuilder:
+Edit .tito/tito.props to change the builder to the GitAnnexBuilder:
 
     [globalconfig]
     default_builder = tito.builder.GitAnnexBuilder

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,12 +1,12 @@
 [globalconfig]
 default_builder = tito.builder.Builder
 default_tagger = tito.tagger.VersionTagger
-lib_dir = rel-eng/custom/
+lib_dir = .tito/custom/
 
 [buildconfig]
 builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
-lib_dir = rel-eng/custom/
+lib_dir = .tito/custom/
 
 [tag1]
 disttag = el5

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -358,7 +358,7 @@ class Builder(ConfigObject, BuilderBase):
         self.relative_project_dir = get_relative_project_dir(
             project_name=self.project_name, commit=self.git_commit_id)
         if self.relative_project_dir is None and self.test:
-            sys.stderr.write("WARNING: rel-eng/packages/%s doesn't exist "
+            sys.stderr.write("WARNING: .tito/packages/%s doesn't exist "
                 "in git, using current directory\n" % self.project_name)
             self.relative_project_dir = get_relative_project_dir_cwd(
                 self.git_root)
@@ -510,7 +510,7 @@ class Builder(ConfigObject, BuilderBase):
         """
         Get the package display version to build.
 
-        Normally this is whatever is rel-eng/packages/. In the case of a --test
+        Normally this is whatever is .tito/packages/. In the case of a --test
         build it will be the SHA1 for the HEAD commit of the current git
         branch.
         """

--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -22,8 +22,8 @@ from optparse import OptionParser
 
 from tito.common import find_git_root, error_out, debug, get_class_by_name, \
     BUILDCONFIG_SECTION, DEFAULT_BUILDER, BUILDCONFIG_SECTION, DEFAULT_TAGGER, \
-    create_builder, find_git_root, get_project_name, get_relative_project_dir, \
-    DEFAULT_BUILD_DIR, run_command
+    create_builder, get_project_name, get_relative_project_dir, \
+    DEFAULT_BUILD_DIR, run_command, tito_config_dir
 from tito.compat import RawConfigParser, getstatusoutput, getoutput
 from tito.exception import TitoException
 
@@ -77,14 +77,14 @@ class ConfigLoader(object):
 
     def _read_config(self):
         """
-        Read global build.py configuration from the rel-eng dir of the git
+        Read global build.py configuration from the .tito dir of the git
         repository we're being run from.
 
         NOTE: We always load the latest config file, not tito.props as it
         was for the tag being operated on.
         """
         # List of filepaths to config files we'll be loading:
-        rel_eng_dir = os.path.join(find_git_root(), "rel-eng")
+        rel_eng_dir = os.path.join(find_git_root(), tito_config_dir())
         filename = os.path.join(rel_eng_dir, TITO_PROPS)
         if not os.path.exists(filename):
             error_out("Unable to locate branch configuration: %s"
@@ -491,9 +491,9 @@ class ReleaseModule(BaseCliModule):
 
     def _read_releaser_config(self):
         """
-        Read the releaser targets from rel-eng/releasers.conf.
+        Read the releaser targets from .tito/releasers.conf.
         """
-        rel_eng_dir = os.path.join(find_git_root(), "rel-eng")
+        rel_eng_dir = os.path.join(find_git_root(), tito_config_dir())
         filename = os.path.join(rel_eng_dir, RELEASERS_CONF_FILENAME)
         config = RawConfigParser()
         config.read(filename)
@@ -701,7 +701,7 @@ class InitModule(BaseCliModule):
         # calling main will result in a configuration error.
         should_commit = False
 
-        rel_eng_dir = os.path.join(find_git_root(), "rel-eng")
+        rel_eng_dir = os.path.join(find_git_root(), '.tito')
         print("Creating tito metadata in: %s" % rel_eng_dir)
 
         propsfile = os.path.join(rel_eng_dir, TITO_PROPS)
@@ -736,7 +736,7 @@ class InitModule(BaseCliModule):
             # write out readme file explaining what pkg_dir is for
             readme = os.path.join(pkg_dir, '.readme')
             out_f = open(readme, 'w')
-            out_f.write("the rel-eng/packages directory contains metadata files\n")
+            out_f.write("the .tito/packages directory contains metadata files\n")
             out_f.write("named after their packages. Each file has the latest tagged\n")
             out_f.write("version and the project's relative directory.\n")
             out_f.close()
@@ -795,7 +795,7 @@ class ReportModule(BaseCliModule):
         print("Scanning for packages that may need to be tagged...")
         print("")
         git_root = find_git_root()
-        rel_eng_dir = os.path.join(git_root, "rel-eng")
+        rel_eng_dir = os.path.join(git_root, tito_config_dir())
         os.chdir(git_root)
         package_metadata_dir = os.path.join(rel_eng_dir, "packages")
         for root, dirs, files in os.walk(package_metadata_dir):
@@ -821,7 +821,7 @@ class ReportModule(BaseCliModule):
         print("Scanning for packages that may need to be tagged...")
         print("")
         git_root = find_git_root()
-        rel_eng_dir = os.path.join(git_root, "rel-eng")
+        rel_eng_dir = os.path.join(git_root, tito_config_dir())
         os.chdir(git_root)
         package_metadata_dir = os.path.join(rel_eng_dir, "packages")
         for root, dirs, files in os.walk(package_metadata_dir):

--- a/src/tito/config_object.py
+++ b/src/tito/config_object.py
@@ -15,7 +15,7 @@ Shared code for builder and tagger class
 """
 
 import os
-from tito.common import find_git_root
+from tito.common import find_git_root, tito_config_dir
 
 
 class ConfigObject(object):
@@ -38,4 +38,4 @@ class ConfigObject(object):
                         config.get(section, options))
 
         self.git_root = find_git_root()
-        self.rel_eng_dir = os.path.join(self.git_root, "rel-eng")
+        self.rel_eng_dir = os.path.join(self.git_root, tito_config_dir())

--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -413,7 +413,7 @@ class VersionTagger(ConfigObject):
 
     def _update_package_metadata(self, new_version):
         """
-        We track package metadata in the rel-eng/packages/ directory. Each
+        We track package metadata in the .tito/packages/ directory. Each
         file here stores the latest package version (for the git branch you
         are on) as well as the relative path to the project's code. (from the
         git root)
@@ -462,12 +462,12 @@ class VersionTagger(ConfigObject):
 
     def _clear_package_metadata(self):
         """
-        Remove all rel-eng/packages/ files that have a relative path
+        Remove all .tito/packages/ files that have a relative path
         matching the package we're tagging a new version of. Normally
         this just removes the previous package file but if we were
         renaming oldpackage to newpackage, this would git rm
-        rel-eng/packages/oldpackage and add
-        rel-eng/packages/spacewalk-newpackage.
+        .tito/packages/oldpackage and add
+        .tito/packages/spacewalk-newpackage.
         """
         metadata_dir = os.path.join(self.rel_eng_dir, "packages")
         for filename in os.listdir(metadata_dir):
@@ -546,7 +546,7 @@ class VersionTagger(ConfigObject):
         provide a configuration in tito.props to a file that is a
         python string.Template conforming blob, like
             [version_template]
-            template_file = ./rel-eng/templates/my_java_properties
+            template_file = ./.tito/templates/my_java_properties
 
         variables defined inside the template are $version and $release
 

--- a/test/functional/fetch_tests.py
+++ b/test/functional/fetch_tests.py
@@ -22,7 +22,7 @@ import tempfile
 
 from os.path import join
 
-from tito.common import run_command
+from tito.common import run_command, tito_config_dir
 from tito.compat import *
 from functional.fixture import TitoGitTestFixture, tito
 
@@ -72,7 +72,7 @@ class FetchBuilderTests(TitoGitTestFixture):
     def test_simple_build_no_tag(self):
         # We have not tagged here. Build --rpm should just work:
         self.assertFalse(os.path.exists(
-            join(self.pkg_dir, 'rel-eng/packages/extsrc')))
+            join(self.pkg_dir, '.tito/packages/extsrc')))
 
         tito('build --rpm --output=%s --no-cleanup --debug --arg=source=%s ' %
                 (self.output_dir, self.source_filename))
@@ -87,7 +87,7 @@ class FetchBuilderTests(TitoGitTestFixture):
                 (self.output_dir, self.source_filename))
 
     def _setup_fetchbuilder_releaser(self, yum_repo_dir):
-        self.write_file(join(self.repo_dir, 'rel-eng/releasers.conf'),
+        self.write_file(join(self.repo_dir, '.tito/releasers.conf'),
                 RELEASER_CONF % yum_repo_dir)
 
     def test_with_releaser(self):

--- a/test/functional/fixture.py
+++ b/test/functional/fixture.py
@@ -122,8 +122,8 @@ class TitoGitTestFixture(unittest.TestCase):
 
         # Next we tito init:
         tito("init")
-        run_command('echo "offline = true" >> rel-eng/tito.props')
-        run_command('git add rel-eng/tito.props')
+        run_command('echo "offline = true" >> .tito/tito.props')
+        run_command('git add .tito/tito.props')
         run_command("git commit -m 'set offline in tito.props'")
 
     def tearDown(self):

--- a/test/functional/multiproject_tests.py
+++ b/test/functional/multiproject_tests.py
@@ -48,7 +48,7 @@ builder = tito.builder.Builder
 
 [version_template]
 destination_file = version.txt
-template_file = rel-eng/templates/version.rb
+template_file = .tito/templates/version.rb
 """
 
 VERSION_TEMPLATE_FILE = """
@@ -90,9 +90,9 @@ class MultiProjectTests(TitoGitTestFixture):
         pkg_dir = join(self.repo_dir, 'pkg3')
         filename = join(pkg_dir, "tito.props")
         self.write_file(filename, TEMPLATE_TAGGER_TITO_PROPS)
-        run_command('mkdir -p %s' % join(self.repo_dir, 'rel-eng/templates'))
+        run_command('mkdir -p %s' % join(self.repo_dir, '.tito/templates'))
         self.write_file(join(self.repo_dir,
-            'rel-eng/templates/version.rb'), VERSION_TEMPLATE_FILE)
+            '.tito/templates/version.rb'), VERSION_TEMPLATE_FILE)
 
         os.chdir(self.repo_dir)
         run_command('git add pkg3/tito.props')
@@ -119,7 +119,7 @@ class MultiProjectTests(TitoGitTestFixture):
         for pkg_name in TEST_PKGS:
             self.assertTrue(tag_exists_locally("%s-0.0.1-1" % pkg_name))
             self.assertTrue(os.path.exists(os.path.join(self.repo_dir,
-                "rel-eng/packages", pkg_name)))
+                ".tito/packages", pkg_name)))
 
     def test_release_tagger(self):
         os.chdir(os.path.join(self.repo_dir, 'pkg2'))

--- a/test/functional/release_yum_tests.py
+++ b/test/functional/release_yum_tests.py
@@ -60,7 +60,7 @@ class YumReleaserTests(TitoGitTestFixture):
         pass
 
     def _setup_fetchbuilder_releaser(self, yum_repo_dir):
-        self.write_file(join(self.repo_dir, 'rel-eng/releasers.conf'),
+        self.write_file(join(self.repo_dir, '.tito/releasers.conf'),
                 RELEASER_CONF % yum_repo_dir)
 
     def test_with_releaser(self):

--- a/test/functional/singleproject_tests.py
+++ b/test/functional/singleproject_tests.py
@@ -44,10 +44,10 @@ class SingleProjectTests(TitoGitTestFixture):
     def test_init_worked(self):
         # Not actually running init here, just making sure it worked when
         # run during setup.
-        self.assertTrue(os.path.exists(os.path.join(self.repo_dir, "rel-eng")))
-        self.assertTrue(os.path.exists(os.path.join(self.repo_dir, "rel-eng",
+        self.assertTrue(os.path.exists(os.path.join(self.repo_dir, ".tito")))
+        self.assertTrue(os.path.exists(os.path.join(self.repo_dir, ".tito",
             "packages")))
-        self.assertTrue(os.path.exists(os.path.join(self.repo_dir, "rel-eng",
+        self.assertTrue(os.path.exists(os.path.join(self.repo_dir, ".tito",
             "tito.props")))
 
     def test_initial_tag(self):

--- a/tito.8.asciidoc
+++ b/tito.8.asciidoc
@@ -30,7 +30,7 @@ After setting up a directory as a Git repo, use `tito`
 to manage the tags and builds. A simple workflow may look like:
 
 . Save user preferences as described in `titorc(5)`
-. Initialize a `rel-eng` directory
+. Initialize a `.tito` directory
 . Test
   .. Make changes to source
   .. Use git to commit changes
@@ -48,7 +48,7 @@ OPTIONS
 `tito init`
 ~~~~~~~~~~~
 
-This will create a top-level metadata directory called "rel-eng/" and commit it
+This will create a top-level metadata directory called ".tito/" and commit it
 to git. This directory will store tito's configuration and package metadata on
 a per branch basis. It will be filtered out when creating .tar.gz's.
 
@@ -61,7 +61,7 @@ By default, tito will tag by bumping the rpm version
 (i.e. we bump the Z in X.Y.Z). If you'd prefer to bump the package
 release instead (normally should just be used for changes to the spec file or
 patches applied within it), you can change the tagger class in
-rel-eng/tito.props to ReleaseTagger. This will affect all packages in this git
+.tito/tito.props to ReleaseTagger. This will affect all packages in this git
 branch; if you'd prefer to do this on a per-package basis you can do so in a
 package specific `tito.props`.
 
@@ -174,7 +174,7 @@ src.rpm, because for rpm you want to define this option for specific tag in tito
 `tito release [options] TARGETS`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Runs the release targets defined in rel-eng/releasers.conf.
+Runs the release targets defined in .tito/releasers.conf.
 
 -h, --help::
 show this help message and exit
@@ -202,10 +202,10 @@ Do not perform a brew/koji build, only DistGit commit.
 (only for Koji/DistGit releasers)
 
 --all::
-Run all release targets defined in rel-eng/releasers.conf.
+Run all release targets defined in .tito/releasers.conf.
 
 --list::
-List all release targets defined in rel-eng/releasers.conf.
+List all release targets defined in .tito/releasers.conf.
 
 --all-starting-with=ALL_STARTING_WITH::
 Run all release targets starting with the given string. (i.e.

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -17,11 +17,11 @@ DESCRIPTION
 -----------
 Project settings can be stored in files:
 
-`GITROOT/rel-eng/tito.props`
+`GITROOT/.tito/tito.props`
 
 `GITROOT/SOME/PACKAGE/tito.props`
 
-The global rel-eng/tito.props is generally where settings are defined. For
+The global .tito/tito.props is generally where settings are defined. For
 some multi-project git repositories, individual packages can override these
 settings by placing a tito.props in the project directory. (i.e. same location
 as it's .spec file)
@@ -97,7 +97,7 @@ VERSION_TEMPLATE
 Allows the user to write out a template file containing version and/or release and add it to git during the tagging process.
 
 template_file::
-Path to a file conforming to a Python string.Template, as described at http://docs.python.org/2/library/string.html#template-strings. Path is relative to root of the entire git checkout, as this is likely to be stored in the top level rel-eng directory.  The variables $version and $release are available inside the template.
+Path to a file conforming to a Python string.Template, as described at http://docs.python.org/2/library/string.html#template-strings. Path is relative to root of the entire git checkout, as this is likely to be stored in the top level .tito directory.  The variables $version and $release are available inside the template.
 
 destination_file::
 Specifies a file to write, relative to the directory for the package being tagged.
@@ -107,7 +107,7 @@ Example:
 ----
 [version_template]
 destination_file = version.txt
-template_file = rel-eng/templates/version.rb
+template_file = .tito/templates/version.rb
 ----
 
 
@@ -177,7 +177,7 @@ the automatic git-annex symlinks on completion.
 TAGGERS
 -------
 All taggers which inherit fom tito.tagger.VersionTagger (all to this date),
-will update file GITROOT/rel-eng/packages/name-of-package and put there one
+will update file GITROOT/.tito/packages/name-of-package and put there one
 line which consist of version-release of package, space delimiter, path to
 package directory relative to GITROOT.
 


### PR DESCRIPTION
if /releng is present it will be used. Otherwise /.tito will be used.

The patch is surprisingly small. With major changes in documentation.
I decided to not declare /rel-eng/ as obsolete and ask people for rename as I would like to see this function for at least one release before we call /rel-eng/ obsolete (if ever).