### PR TITLE
bash-completion for tito command

### DIFF
--- a/share/tito_completion.sh
+++ b/share/tito_completion.sh
@@ -1,0 +1,123 @@
+# Copyright (c) 2015 John Florian <jflorian@doubledog.org>
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+__tito_modules='build init release report tag'
+
+# Excluding short options here because they'd save no keystrokes and only make
+# these longer, more intuitive options less accessible.
+__tito_opts='--help'
+
+__tito_build_opts='
+    --arg=
+    --builder=
+    --debug
+    --dist=
+    --help
+    --install
+    --list-tags
+    --no-cleanup
+    --only-tags=
+    --output=
+    --rpm
+    --rpmbuild-options=
+    --scl=
+    --srpm
+    --tag=
+    --test
+    --tgz
+'
+
+__tito_release_opts='
+    --all
+    --all-starting-with=
+    --debug
+    --dry-run
+    --help
+    --list
+    --no-build
+    --no-cleanup
+    --output=
+    --scratch
+    --tag=
+    --test
+    --yes
+'
+
+__tito_report_opts='
+    --debug
+    --help
+    --output=
+    --untagged-diffs
+    --untagged-commits
+'
+
+__tito_tag_opts='
+    --accept-auto-changelog
+    --auto-changelog-message=
+    --debug
+    --help
+    --keep-version
+    --no-auto-changelog
+    --output=
+    --undo
+    --use-version=
+'
+
+_tito_get_release_targets() {
+    # Ideally tito would return an exit code of 0 upon success, but it seems
+    # to return 1 whether run within a git checkout or not.  Hence this
+    # kludge:
+    if tito release --list 2> /dev/null | grep -q 'Available release targets'
+    then
+        tito release --list | tail -n +2
+    fi
+}
+
+_tito() {
+    local cur opts module
+
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    module="${COMP_WORDS[1]}"
+
+    opts="${__tito_modules} ${__tito_opts}"
+
+    case "${module}" in
+
+        build)
+            COMPREPLY=( $(compgen -W "${__tito_build_opts}" -- ${cur}) )
+            return 0
+            ;;
+
+        release)
+            COMPREPLY=( $(compgen -W \
+                        "${__tito_release_opts} $(_tito_get_release_targets)" \
+                        -- ${cur}) \
+                      )
+            return 0
+            ;;
+
+        report)
+            COMPREPLY=( $(compgen -W "${__tito_report_opts}" -- ${cur}) )
+            return 0
+            ;;
+
+        tag)
+            COMPREPLY=( $(compgen -W "${__tito_tag_opts}" -- ${cur}) )
+            return 0
+            ;;
+
+    esac
+
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+
+complete -F _tito tito

--- a/tito.spec
+++ b/tito.spec
@@ -92,6 +92,8 @@ rm -f $RPM_BUILD_ROOT%{python_sitelib}/*egg-info/requires.txt
 %{__mkdir_p} %{buildroot}%{_mandir}/man8
 cp -a titorc.5 tito.props.5 releasers.conf.5 %{buildroot}/%{_mandir}/man5/
 cp -a tito.8 %{buildroot}/%{_mandir}/man8/
+# bash completion facilities
+install -Dp -m 0644 share/tito_completion.sh %{buildroot}%{_datadir}/bash-completion/completions/tito
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -108,6 +110,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/tar-fixup-stamp-comment.pl
 %{_bindir}/test-setup-specfile.pl
 %{_bindir}/generate-patches.pl
+%{_datadir}/bash-completion/completions/tito
 %dir %{python_sitelib}/tito
 %{python_sitelib}/tito/*
 %{python_sitelib}/tito-*.egg-info


### PR DESCRIPTION
Here's an initial go at getting some bash-completion for the tito command.
Module options are a union of those culled from both "tito MODULE --help" and
"man tito" -- there are discrepancies.  Some options were deliberately omitted
such as those documented as deprecated or "avoid using this please".  All
short options are also omitted as their completion would not save any typing
but would hinder the accessibility of the longer options.
