### PR TITLE
try to find spec file in some subdirectories too

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -229,20 +229,31 @@ def create_builder(package_name, build_tag,
     return builder
 
 
-def find_file_with_extension(in_dir=None, suffix=None):
+def find_file_with_extension(in_dir=None, suffix=None, top=True):
     """ Find the file with given extension in the current directory. """
     if in_dir is None:
         in_dir = os.getcwd()
     file_name = None
     debug("Looking for %s in %s" % (suffix, in_dir))
+    if not os.path.isdir(in_dir):
+        return None
     for f in os.listdir(in_dir):
         if f.endswith(suffix):
             if file_name is not None:
                 error_out("At least two %s files in directory: %s and %s" % (suffix, file_name, f))
             file_name = f
-            debug("Using file: %s" % f)
+            debug("Using file: %s" % os.path.join(in_dir, f))
     if file_name is None:
-        error_out("Unable to locate a %s file in %s" % (suffix, in_dir))
+        if top:
+            sub_dir_list = ["distribution", "dist", "packaging", "spec", "contrib"]
+            for sub_dir in sub_dir_list:
+                file_name = find_file_with_extension(os.path.join(in_dir, sub_dir), suffix, top=False)
+                if file_name:
+                    return os.path.join(sub_dir, file_name)
+            error_out("Unable to locate a {0} file in {1} (and in {2} sub directories)".format(suffix,
+                in_dir, ', '.join(sub_dir_list)))
+        else:
+            return None
     else:
         return file_name
 

--- a/test/functional/fixture.py
+++ b/test/functional/fixture.py
@@ -188,3 +188,16 @@ class TitoGitTestFixture(unittest.TestCase):
 
         if tag:
             tito('tag --keep-version --debug --accept-auto-changelog')
+
+    def create_project_with_spec_moved(self, pkg_name, pkg_dir='', tag=True):
+        """
+        Create a test project at the given location, assumed to be within
+        our test repo, but possibly within a sub-directory.
+        Spec file is moved to directory 'packaging'.
+        """
+        self.create_project(pkg_name, pkg_dir, tag)
+        full_pkg_dir1 = os.path.join(self.repo_dir, pkg_dir)
+        full_pkg_dir2 = os.path.join(self.repo_dir, pkg_dir, 'packaging')
+        os.mkdir(full_pkg_dir2)
+        os.rename(os.path.join(full_pkg_dir1, "%s.spec" % pkg_name),
+            os.path.join(full_pkg_dir2, "%s.spec" % pkg_name))

--- a/test/functional/multiproject_tests.py
+++ b/test/functional/multiproject_tests.py
@@ -17,11 +17,13 @@ Functional Tests for Tito at the CLI level.
 NOTE: These tests require a makeshift git repository created in /tmp.
 """
 
+from mock import patch
 import os
 from os.path import join
+import sys
 
 from tito.common import run_command, \
-    get_latest_tagged_version, tag_exists_locally
+    get_latest_tagged_version, tag_exists_locally, find_file_with_extension
 from functional.fixture import *
 
 # A location where we can safely create a test git repository.
@@ -67,7 +69,7 @@ class MultiProjectTests(TitoGitTestFixture):
 
         self.create_project(TEST_PKG_1, os.path.join(self.repo_dir, 'pkg1'))
         self.create_project(TEST_PKG_2, os.path.join(self.repo_dir, 'pkg2'))
-        self.create_project(TEST_PKG_3, os.path.join(self.repo_dir, 'pkg3'))
+        self.create_project_with_spec_moved(TEST_PKG_3, os.path.join(self.repo_dir, 'pkg3'))
 
         # For second test package, use a tito.props to override and use the
         # ReleaseTagger:
@@ -139,3 +141,8 @@ class MultiProjectTests(TitoGitTestFixture):
         os.chdir(os.path.join(self.repo_dir, 'pkg1'))
         artifacts = tito('build --rpm')
         self.assertEquals(3, len(artifacts))
+
+    def test_find_file_with_extension(self):
+        self.assertEquals(find_file_with_extension(os.path.join(self.repo_dir, 'pkg1'), '.spec'), '{0}.spec'.format(TEST_PKG_1))
+        self.assertEquals(find_file_with_extension(os.path.join(self.repo_dir, 'pkg3'), '.spec'), 'packaging/{0}.spec'.format(TEST_PKG_3))
+        self.assertRaises(SystemExit, find_file_with_extension, self.repo_dir, '.spec')

--- a/test/functional/singleproject_tests.py
+++ b/test/functional/singleproject_tests.py
@@ -116,3 +116,6 @@ class SingleProjectTests(TitoGitTestFixture):
         self.assertTrue(isinstance(releaser.builder,
             UpstreamBuilder))
         releaser.release(dry_run=True)
+
+    def test_find_file_with_extension(self):
+        self.assertTrue(find_file_with_extension(self.repo_dir, '.spec') == '{}.spec'.format(PKG_NAME))


### PR DESCRIPTION
Some projects hesitate to put spec file in top levele directories and use "packaging" or "dist". Try to look there too.

This is second take after #162. This time with test.