### PR TITLE
Add RHPKG/FEDPKG_USER to be passed to rh/fedpkg

### DIFF
--- a/src/tito/release/distgit.py
+++ b/src/tito/release/distgit.py
@@ -23,6 +23,7 @@ from tito.compat import getoutput, getstatusoutput, write
 from tito.release import Releaser
 from tito.release.main import PROTECTED_BUILD_SYS_FILES
 from tito.buildparser import BuildTargetParser
+from tito.cli import read_user_config
 
 
 class FedoraGitReleaser(Releaser):
@@ -37,6 +38,11 @@ class FedoraGitReleaser(Releaser):
         Releaser.__init__(self, name, tag, build_dir, config,
                 user_config, target, releaser_config, no_cleanup, test,
                 auto_accept, **kwargs)
+
+        if 'FEDPKG_USER' in user_config:
+             cli_tool = "fedpkg --user=%s" % user_config["FEDPKG_USER"]
+        else:
+             cli_tool = "fedpkg"
 
         self.git_branches = \
             self.releaser_config.get(self.target, "branches").split(" ")
@@ -384,8 +390,11 @@ class FedoraGitReleaser(Releaser):
 
 
 class DistGitReleaser(FedoraGitReleaser):
-    cli_tool = "rhpkg"
-
+    user_config = read_user_config()
+    if "RHPKG_USER" in user_config:
+         cli_tool = "rhpkg --user=%s" % user_config["RHPKG_USER"]
+    else:
+         cli_tool = "rhpkg"
 
 def extract_task_info(output):
     """ Extracts task ID and URL from koji/brew build output. """

--- a/titorc.5.asciidoc
+++ b/titorc.5.asciidoc
@@ -45,6 +45,12 @@ changelog entries. I.e. instead of
 You will get:
  * Tue Feb 11 2011 Miroslav Suchy 0.3.0-2
 
+RHPKG_USER::
+FEDPKG_USER::
+By default this is the UNIX user running the command. Overriding it will run
+all rhpkg/fedpkg commands with --user $RHPKG_USER/FEDPKG_USER
+
+
 EXAMPLE
 -------
 KOJI_OPTIONS=-c ~/.koji/spacewalkproject.org-config build --nowait


### PR DESCRIPTION
Specifying these values on .titorc will allow to use tito without having to create a specific username in Linux for it, in case your username in git is different than the one on your computer.