### PR TITLE
Fix rpmbuild_options array handling from builder args

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -74,8 +74,11 @@ class BuilderBase(object):
         self.scl = self._get_optional_arg(args, 'scl', [None])[0] or \
                 self._get_optional_arg(kwargs, 'scl', '')
 
-        self.rpmbuild_options = self._get_optional_arg(args, 'rpmbuild_options', None) or \
-                self._get_optional_arg(kwargs, 'rpmbuild_options', '')
+        rpmbuildopts = self._get_optional_arg(args, 'rpmbuild_options', None)
+        if rpmbuildopts:
+            self.rpmbuild_options = ' '.join(rpmbuildopts)
+        else:
+            self.rpmbuild_options = self._get_optional_arg(kwargs, 'rpmbuild_options', '')
 
         self.test = self._get_optional_arg(kwargs, 'test', False)
         # Allow a builder arg to override the test setting passed in, used by

--- a/test/functional/builder_tests.py
+++ b/test/functional/builder_tests.py
@@ -46,8 +46,9 @@ class BuilderTests(TitoGitTestFixture):
     def test_rpmbuild_options_from_options(self):
         self.create_project(PKG_NAME)
         builder = Builder(PKG_NAME, None, self.output_dir,
-            self.config, {}, {'rpmbuild_options': '--define "foo bar"'}, **{'offline': True})
-        self.assertEqual('--define "foo bar"', builder.rpmbuild_options)
+            self.config, {}, {'rpmbuild_options': ['--define "foo bar"',
+            '--define "bar baz"']}, **{'offline': True})
+        self.assertEqual('--define "foo bar" --define "bar baz"', builder.rpmbuild_options)
 
     def test_rpmbuild_options_from_kwargs(self):
         self.create_project(PKG_NAME)


### PR DESCRIPTION
3892359 changed builder args to always be arrays, so concatenation of
rpmbuild options with other strings then failed.

    File "/usr/lib/python2.7/site-packages/tito/release/main.py", line 530, in _koji_release
      builder.srpm(dist=disttag)
    File "/usr/lib/python2.7/site-packages/tito/builder/main.py", line 210, in srpm
      rpmbuild_options = self.rpmbuild_options + self._scl_to_rpmbuild_option()
    TypeError: can only concatenate list (not "str") to list

Change builder args to be joined by a single space, allowing multiple
arguments to be passed in.