### PR TITLE
Allow a user specific Copr remote SRPM URL.

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -67,7 +67,8 @@ def read_user_config():
         tokens = line.split("=")
         if len(tokens) != 2:
             raise Exception("Error parsing ~/.titorc: %s" % line)
-        config[tokens[0]] = tokens[1].strip()
+        # Remove whitespace from the values
+        config[tokens[0].strip()] = tokens[1].strip()
     return config
 
 

--- a/src/tito/release/main.py
+++ b/src/tito/release/main.py
@@ -23,7 +23,7 @@ from tempfile import mkdtemp
 import shutil
 
 from tito.common import create_builder, debug, \
-    run_command, get_project_name, warn_out
+    run_command, get_project_name, warn_out, error_out
 from tito.compat import PY2, dictionary_override
 from tito.exception import TitoException
 from tito.config_object import ConfigObject
@@ -115,13 +115,11 @@ class Releaser(ConfigObject):
         """
         for opt in self.GLOBAL_REQUIRED_CONFIG:
             if not self.releaser_config.has_option(self.target, opt):
-                raise TitoException(
-                    "Release target '%s' missing required option '%s'" %
+                error_out("Release target '%s' missing required option '%s'" %
                     (self.target, opt))
         for opt in self.REQUIRED_CONFIG:
             if not self.releaser_config.has_option(self.target, opt):
-                raise TitoException(
-                    "Release target '%s' missing required option '%s'" %
+                error_out("Release target '%s' missing required option '%s'" %
                     (self.target, opt))
 
         # TODO: accomodate 'builder.*' for yum releaser and we can use this:

--- a/test/functional/release_copr_tests.py
+++ b/test/functional/release_copr_tests.py
@@ -19,6 +19,7 @@ from functional.fixture import TitoGitTestFixture
 
 from tito.compat import *  # NOQA
 from tito.release import CoprReleaser
+from unit import Capture
 
 PKG_NAME = "releaseme"
 
@@ -61,3 +62,19 @@ class CoprReleaserTests(TitoGitTestFixture):
             False, False, **{'offline': True})
         releaser.release(dry_run=True)
         self.assertTrue(releaser.srpm_submitted is not None)
+
+    def test_with_remote_defined_in_user_conf(self):
+        self.releaser_config.remove_option("test", "remote_location")
+        user_config = {'COPR_REMOTE_LOCATION': 'http://example.com/~otheruser/'}
+        releaser = CoprReleaser(PKG_NAME, None, '/tmp/tito/',
+            self.config, user_config, 'test', self.releaser_config, False,
+            False, False, **{'offline': True})
+        releaser.release(dry_run=True)
+        self.assertTrue(releaser.srpm_submitted is not None)
+
+    def test_no_remote_defined(self):
+        self.releaser_config.remove_option("test", "remote_location")
+        with Capture(silent=True):
+            self.assertRaises(SystemExit, CoprReleaser, PKG_NAME, None, '/tmp/tito/',
+                self.config, {}, 'test', self.releaser_config, False,
+                False, False, **{'offline': True})

--- a/titorc.5.asciidoc
+++ b/titorc.5.asciidoc
@@ -58,6 +58,8 @@ The username to use when pushing the repository MEAD is going to build
 from.  If this value is unset, the MEAD releaser will default to using
 the name of the current user.
 
+COPR_REMOTE_LOCATION::
+URL that Tito will push SRPMs to for Copr to use.
 
 EXAMPLE
 -------


### PR DESCRIPTION
By using a user specific URL, multiple members of the same team can
submit Copr releases without having to share credentials to the SRPM
remote location.  For example, each member of the team can set
COPR_REMOTE_LOCATION in .titorc to their <username>.fedorapeople.org
space.

The URL defined in the releaser will take precedence.