### PR TITLE
Suggest correct path when spec is in subdirectory; Fix #196

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -324,7 +324,7 @@ def find_spec_file(in_dir=None):
     result = find_file_with_extension(in_dir, '.spec')
     if result is None:
         error_out("Unable to locate a %s file in %s" % ('.spec', in_dir))
-    return result
+    return os.path.basename(result)
 
 
 def find_gemspec_file(in_dir=None):


### PR DESCRIPTION
Reason of this pull request is described in the issue #196.

Since there is comment `Returns only the file name, rather than the full path.` in `find_spec_file` function, I think the proposed change is ok. If there is some problem with it, I would propose just this:

    diff --git a/src/tito/builder/main.py b/src/tito/builder/main.py
    index 5819631..5b1e995 100644
    --- a/src/tito/builder/main.py
    +++ b/src/tito/builder/main.py
    @@ -248,7 +248,7 @@ def rpm(self):
                 if re.search('Failed build dependencies', err.output):
                     cmd = "dnf builddep %s" if package_manager() == "dnf" else "yum-builddep %s"
                     msg = "Please run '%s' as root." % \
    -                    cmd % find_spec_file(self.relative_project_dir)
    +                    cmd % find_spec_file(os.path.basename(self.relative_project_dir))
                 error_out('%s' % msg)
             except Exception:
                 err = sys.exc_info()[1]
