### PR TITLE
Add possibility to upload SRPM directly to Copr

### DIFF
--- a/releasers.conf.5.asciidoc
+++ b/releasers.conf.5.asciidoc
@@ -144,7 +144,7 @@ but if it is not present name of package directory is used.
 This releaser assume that you have ~/.oscrc correctly configured.
 
 tito.release.CoprReleaser::
-This releaser publish your src.rpm on internet and submit it to Copr.
+This releaser submits your src.rpm to Copr.
 
  [my-copr]
  releaser = tito.release.CoprReleaser
@@ -155,8 +155,10 @@ This releaser publish your src.rpm on internet and submit it to Copr.
 Variables are:
 
  * project_name - this is name of your project on Copr
- * upload_command - this command is executed to upload src.rpm to internet. It can be scp, rsync or just cp. It may containt string "%(srpm)s" (even several times), which is substitued by real srpm path.
- * remote_location - how can be accessed the location above over www.
+ * upload_command - this command is executed to upload src.rpm to internet. It can be scp, rsync or just cp. It may containt string "%(srpm)s" (even several times), which is substitued by real srpm path. (optional)
+ * remote_location - how can be accessed the location above over www. (optional)
+
+The releaser will publish your src.rpm to remote server and then submit it into Copr via URL. If you rather want to submit the package directly from your computer, just omit "upload_command" and "remote_location" variables.
 
 Project_name behave exactly as "autobuild_tags" in KojiReleaser, and you can define various options for each project name in tito.props (e.g. disttag, whitelist, blacklist, scl). For more information see man page of tito.props.
 
@@ -218,9 +220,14 @@ EXAMPLE
  releaser=tito.release.ObsReleaser
  project_name=home:xsuchy
 
+ ; Upload src.rpm to remote server and then submit it into Copr via URL
  [copr-project]
  releaser = tito.release.CoprReleaser
  project_name = my-copr-project-name another-project
  upload_command = cp %(srpm)s /home/msuchy/public_html/my_srpm/
  remote_location = http://my.web.com/~msuchy/my_srpm/
 
+ ; Submit src.rpm from your computer directly to Copr
+ [copr-project]
+ releaser = tito.release.CoprReleaser
+ project_name = my-copr-project-name another-project

--- a/src/tito/release/copr.py
+++ b/src/tito/release/copr.py
@@ -105,3 +105,5 @@ class CoprReleaser(KojiReleaser):
     def _run_command(self, cmd):
         process = subprocess.Popen(cmd.split())
         process.wait()
+        if process.returncode > 0:
+            error_out("Failed running `%s`" % cmd)

--- a/test/functional/release_copr_tests.py
+++ b/test/functional/release_copr_tests.py
@@ -17,6 +17,7 @@ Functional Tests for the CoprReleaser.
 
 from functional.fixture import TitoGitTestFixture
 
+import mock
 from tito.compat import *  # NOQA
 from tito.release import CoprReleaser
 from unit import Capture
@@ -72,9 +73,14 @@ class CoprReleaserTests(TitoGitTestFixture):
         releaser.release(dry_run=True)
         self.assertTrue(releaser.srpm_submitted is not None)
 
-    def test_no_remote_defined(self):
+    @mock.patch("tito.release.CoprReleaser._submit")
+    @mock.patch("tito.release.CoprReleaser._upload")
+    def test_no_remote_defined(self, upload, submit):
         self.releaser_config.remove_option("test", "remote_location")
-        with Capture(silent=True):
-            self.assertRaises(SystemExit, CoprReleaser, PKG_NAME, None, '/tmp/tito/',
-                self.config, {}, 'test', self.releaser_config, False,
-                False, False, **{'offline': True})
+        releaser = CoprReleaser(PKG_NAME, None, '/tmp/tito/',
+            self.config, {}, 'test', self.releaser_config, False,
+            False, False, **{'offline': True})
+        releaser.release(dry_run=True)
+
+        self.assertFalse(upload.called)
+        self.assertTrue(submit.called)


### PR DESCRIPTION
Additionally to the current `CoprReleaser` behavior in which the builded SRPM is uploaded to remote server and then submitted to the Copr via URL, I have implemented direct approach for submitting the package from your local storage right into the Copr. This feature is supported since `python-copr-1.58-1`.

With this patch it's supported the old style configuration:
    
    [copr]
    releaser = tito.release.CoprReleaser
    project_name = foo
    upload_command = scp %(srpm)s user@example.com:/home/user/public_html/
    remote_location = http://example.com/~user/

as well as the:

    [copr]
    releaser = tito.release.CoprReleaser
    project_name = foo

Can you review it @xsuchy and give me your blessing? :-)