### PR TITLE
Fix changelog format function name

### DIFF
--- a/src/tito/tagger/rheltagger.py
+++ b/src/tito/tagger/rheltagger.py
@@ -28,7 +28,7 @@ class RHELTagger(ReleaseTagger):
         - Resolves: #1111 - description
         """
         patch_command = "git log --pretty='format:%%s%s'" \
-                         " --relative %s..%s -- %s" % (self._changelog_email(), last_tag, "HEAD", ".")
+                         " --relative %s..%s -- %s" % (self._changelog_format(), last_tag, "HEAD", ".")
         output = run_command(patch_command)
         BZ = {}
         result = None


### PR DESCRIPTION
Use _changelog_format() instead of _changelog_email() which no longer
exists.