### PR TITLE
Added ability to pass extra copr-cli build options to the copr releaser.

### DIFF
--- a/releasers.conf.5.asciidoc
+++ b/releasers.conf.5.asciidoc
@@ -151,12 +151,14 @@ This releaser submits your src.rpm to Copr.
  project_name = my-copr-project-name
  upload_command = scp %(srpm)s my.web.com:public_html/my_srpm/
  remote_location = http://my.web.com/~msuchy/my_srpm/
+ copr_options = --timeout 600
 
 Variables are:
 
  * project_name - this is name of your project on Copr
  * upload_command - this command is executed to upload src.rpm to internet. It can be scp, rsync or just cp. It may containt string "%(srpm)s" (even several times), which is substitued by real srpm path. (optional)
  * remote_location - how can be accessed the location above over www. (optional)
+ * copr_options - space separated options to pass directly to `copr-cli build`. Defaults to --nowait. (optional)
 
 The releaser will publish your src.rpm to remote server and then submit it into Copr via URL. If you rather want to submit the package directly from your computer, just omit "upload_command" and "remote_location" variables.
 
@@ -231,3 +233,9 @@ EXAMPLE
  [copr-project]
  releaser = tito.release.CoprReleaser
  project_name = my-copr-project-name another-project
+
+ ; Submit src.rpm from your computer directly to Copr, timeout after 10 minutes
+ [copr-project]
+ releaser = tito.release.CoprReleaser
+ project_name = my-copr-project-name another-project
+ copr_options = --timeout 600

--- a/src/tito/release/copr.py
+++ b/src/tito/release/copr.py
@@ -39,6 +39,13 @@ class CoprReleaser(KojiReleaser):
             self.releaser_config.get(self.target, "project_name")
         self.srpm_submitted = False
 
+        # 'copr-cli build' options, e.g. --chroot
+        # Default to --nowait, so that it mirrors the behavior of fedpkg
+        self.copr_options = '--nowait'
+        if self.releaser_config.has_option(self.target, "copr_options"):
+            self.copr_options = \
+                self.releaser_config.get(self.target, "copr_options")
+
     def autobuild_tags(self):
         """ will return list of project for which we are building """
         result = self.releaser_config.get(self.target, "project_name")
@@ -93,8 +100,8 @@ class CoprReleaser(KojiReleaser):
             self.srpm_submitted = srpm_location
 
     def _submit(self, srpm_location):
-        cmd_submit = "/usr/bin/%s build %s %s" % \
-                     (self.cli_tool, self.releaser_config.get(self.target, "project_name"), srpm_location)
+        cmd_submit = "/usr/bin/%s build %s %s %s" % \
+                     (self.cli_tool, self.copr_options, self.releaser_config.get(self.target, "project_name"), srpm_location)
         if self.dry_run:
             self.print_dry_run_warning(cmd_submit)
             return


### PR DESCRIPTION
This adds the ability to add 'copr-cli build' options to the releasers.conf file for the copr releaser.

My team will use this specifically for --nowait so that we can submit builds and move on.

This could be useful for the other options, like --memory, --chroot, --timeout, etc.

Here is an example releasers.conf file that works:
```
[copr-openshift-tools]
releaser = tito.release.CoprReleaser
project_name = openshift-tools
build_options = --nowait
```

Not specifying build_options in the config file also works (it's completely optional).