### PR TITLE
Ensure GitAnnexBuilder cleanup returns to proper directory

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -1179,8 +1179,8 @@ class GitAnnexBuilder(NoTgzBuilder):
     def _setup_sources(self):
         super(GitAnnexBuilder, self)._setup_sources()
 
-        old_cwd = os.getcwd()
-        os.chdir(os.path.join(old_cwd, self.relative_project_dir))
+        self.old_cwd = os.getcwd()
+        os.chdir(os.path.join(self.old_cwd, self.relative_project_dir))
 
         # NOTE: 'which' may not be installed... (docker containers)
         (status, output) = getstatusoutput("which git-annex")
@@ -1200,9 +1200,10 @@ class GitAnnexBuilder(NoTgzBuilder):
             shutil.copy(annex, self.rpmbuild_gitcopy)
 
         self._lock()
-        os.chdir(old_cwd)
+        os.chdir(self.old_cwd)
 
     def cleanup(self):
+        os.chdir(self.old_cwd)
         self._lock()
         super(GitAnnexBuilder, self).cleanup()
 


### PR DESCRIPTION
In some cases, we aren't always assured that the releaser will return
us back to proper directory to re-lock the git annex file. This is
the case with the DistGitBuilder for example. This ensures we store
and return to the proper directory before issuing the lock on cleanup