### PR TITLE
remove dependency on yum-utils

### DIFF
--- a/tito.spec
+++ b/tito.spec
@@ -72,7 +72,6 @@ Requires: fedpkg
 Requires: fedora-cert
 Requires: fedora-packager
 Requires: rpmdevtools
-Requires: yum-utils
 # Cheetah doesn't exist for Python 3, but it's what Mead uses.  We
 # install it and call via the command line instead of importing the
 # potentially incompatible code


### PR DESCRIPTION
This was added in commit 9ce944264222d24558d9fb72d9684a267189895a and is not actually needed.
We have it just because we print
   Failed build dependencies
   Please run 'yum-builddep %s' as root.

So it should be rather replaced by:
   Suggest: yum-utils
But that cannot be parsed on el6 and is in fact not needed on F23+ at all.
So it should be rather described by rich deps like
   Suggest: (yum-utils if yum) and (dnf-plugins-core if dnf)
But rich deps should not be used for now.

So lets remove it for now. So yum-utils can be safely retired in rawhide.