### PR TITLE
better release number for untagged packages

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -879,6 +879,15 @@ def get_commit_count(tag, commit_id):
 
     if status != 0:
         debug("git describe of tag %s failed (%d)" % (tag, status))
+        debug("going to use number of commits from initial commit")
+        (status, output) = getstatusoutput(
+            "git rev-list --max-parents=0 HEAD")
+        if status == 0:
+            # output is now inital commit
+            (status, output) = getstatusoutput(
+                "git rev-list %s..%s --count" % (output, commit_id))
+            if status == 0:
+                return output
         return 0
 
     if tag != output:


### PR DESCRIPTION
If package is unttaged and you build it with --test then previously 0 was used as number of commits
since last tag.
This results in packages which has no upgrade path.
With this patch it use number of commits since initial commit, which is growing number.
Therefore packages can be upgraded without usage of --force.