### PR TITLE
Added `--use-release` flag for `tito tag`

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -15,9 +15,10 @@
 """
 Executes all tests.
 """
-
-import sys
 import os
+import shutil
+import sys
+import tempfile
 
 # Make sure we run from the source, this is tricky because the functional
 # tests need to find both the location of the 'tito' executable script,
@@ -38,5 +39,10 @@ if __name__ == '__main__':
     print("Using Python %s" % sys.version[0:3])
     print("Using nose %s" % nose.__version__[0:3])
     print("Running tito tests against: %s" % SRC_DIR)
+
+    # Make sure no older test directories exist
+    for dir in os.listdir(tempfile.gettempdir()):
+        if dir.endswith('-titotest'):
+            shutil.rmtree(os.path.join(tempfile.gettempdir(), dir))
 
     nose.main()

--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -620,6 +620,8 @@ class TagModule(BaseCliModule):
                     "specified in spec file to tag package."))
         self.parser.add_option("--use-version", dest="use_version",
                 help=("Update the spec file with the specified version."))
+        self.parser.add_option("--use-release", dest="use_release",
+                help=("Update the spec file with the specified release."))
 
         self.parser.add_option("--no-auto-changelog", action="store_true",
                 default=False,

--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -100,6 +100,8 @@ class VersionTagger(ConfigObject):
             self._new_changelog_msg = options.auto_changelog_msg
         if options.use_version:
             self._use_version = options.use_version
+        if options.use_release:
+            self._use_release = options.use_release
         if options.changelog:
             self._changelog = options.changelog
 
@@ -414,13 +416,6 @@ class VersionTagger(ConfigObject):
                                         self._use_version,
                                         "\n"
                         ))
-
-                    match = re.match(release_regex, line)
-                    if match:
-                        line = "".join((match.group(1),
-                                        reset_release(match.group(2)),
-                                        "\n"
-                        ))
                 else:
                     match = re.match(version_regex, line)
                     if match:
@@ -429,12 +424,21 @@ class VersionTagger(ConfigObject):
                                         "\n"
                         ))
 
-                    match = re.match(release_regex, line)
-                    if match:
-                        line = "".join((match.group(1),
-                                        reset_release(match.group(2)),
-                                        "\n"
-                        ))
+                if not release and not zstream:
+                    if hasattr(self, '_use_release'):
+                        match = re.match(release_regex, line)
+                        if match:
+                            line = "".join((match.group(1),
+                                            self._use_release,
+                                            "\n"
+                            ))
+                    else:
+                        match = re.match(release_regex, line)
+                        if match:
+                            line = "".join((match.group(1),
+                                            reset_release(match.group(2)),
+                                            "\n"
+                            ))
 
                 out_f.write(line)
 

--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -395,50 +395,30 @@ class VersionTagger(ConfigObject):
             out_f = open(self.spec_file + ".new", 'w')
 
             for line in in_f.readlines():
-                if release:
-                    match = re.match(release_regex, line)
-                    if match:
-                        line = "".join((match.group(1),
-                                        increase_version(match.group(2)),
-                                        "\n"
-                        ))
-                elif zstream:
-                    match = re.match(release_regex, line)
-                    if match:
-                        line = "".join((match.group(1),
-                                        increase_zstream(match.group(2)),
-                                        "\n"
-                        ))
-                elif hasattr(self, '_use_version'):
-                    match = re.match(version_regex, line)
-                    if match:
-                        line = "".join((match.group(1),
-                                        self._use_version,
-                                        "\n"
-                        ))
-                else:
-                    match = re.match(version_regex, line)
-                    if match:
-                        line = "".join((match.group(1),
-                                        increase_version(match.group(2)),
-                                        "\n"
-                        ))
+                version_match = re.match(version_regex, line)
+                release_match = re.match(release_regex, line)
 
-                if not release and not zstream:
-                    if hasattr(self, '_use_release'):
-                        match = re.match(release_regex, line)
-                        if match:
-                            line = "".join((match.group(1),
-                                            self._use_release,
-                                            "\n"
-                            ))
+                if version_match and not zstream and not release:
+                    current_version = version_match.group(2)
+                    if hasattr(self, '_use_version'):
+                        updated_content = self._use_version
                     else:
-                        match = re.match(release_regex, line)
-                        if match:
-                            line = "".join((match.group(1),
-                                            reset_release(match.group(2)),
-                                            "\n"
-                            ))
+                        updated_content = increase_version(current_version)
+
+                    line = "".join([version_match.group(1), updated_content, "\n"])
+
+                elif release_match:
+                    current_release = release_match.group(2)
+                    if hasattr(self, '_use_release'):
+                        updated_content = self._use_release
+                    elif release:
+                        updated_content = increase_version(current_release)
+                    elif zstream:
+                        updated_content = increase_zstream(current_release)
+                    else:
+                        updated_content = reset_release(current_release)
+
+                    line = "".join([release_match.group(1), updated_content, "\n"])
 
                 out_f.write(line)
 

--- a/test/functional/fixture.py
+++ b/test/functional/fixture.py
@@ -128,7 +128,6 @@ class TitoGitTestFixture(unittest.TestCase):
 
     def tearDown(self):
         run_command('chmod -R u+rw %s' % self.repo_dir)
-        shutil.rmtree(self.repo_dir)
         pass
 
     def write_file(self, path, contents):

--- a/test/functional/singleproject_tests.py
+++ b/test/functional/singleproject_tests.py
@@ -62,6 +62,14 @@ class SingleProjectTests(TitoGitTestFixture):
         tito("tag --accept-auto-changelog --debug --use-version 9.0.0")
         check_tag_exists("%s-9.0.0-1" % PKG_NAME, offline=True)
 
+    def test_tag_with_release(self):
+        tito("tag --accept-auto-changelog --debug --use-release dummyvalue")
+        check_tag_exists("%s-0.0.2-dummyvalue" % PKG_NAME, offline=True)
+
+    def test_tag_with_version_and_release(self):
+        tito("tag --accept-auto-changelog --debug --use-version 9.0.0 --use-release dummyvalue")
+        check_tag_exists("%s-9.0.0-dummyvalue" % PKG_NAME, offline=True)
+
     def test_tag_with_changelog(self):
         tito("tag --accept-auto-changelog --use-version 9.0.0 --changelog='-Test'")
         check_tag_exists("%s-9.0.0-1" % PKG_NAME, offline=True)


### PR DESCRIPTION

#### Added `--use-release` flag for `tito tag`

When multiple tags exist for one version of a project, or when a version
is passed to `tito tag --use-version` that does not exactly correspond
with a tag in the repository's git history, the auto-generated release
is not guaranteed to monotonically increase. In order for users to
overcome this issue without building complicated logic into `tito`, it
is simpler to allow users to provide a literal release string to use.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

#### Simplified version and release update logic

The logic that previously existed for updating the version and/or the
release in the specfile contained a lot of repetition and enough boolean
logic that it was becoming hard to read. By simplifying that stanza, the
hope is that the resulting code is easier to understand.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>