### PR TITLE
explain how automatic tagging was done

### DIFF
--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -499,7 +499,8 @@ class VersionTagger(ConfigObject):
             raise TitoException('Unknown placeholder %s in tag_commit_message_format'
                                 % exc)
 
-        run_command('git commit -m %s' % quote(msg))
+        run_command('git commit -m {0} -m {1} -m {2}'.format(
+            quote(msg), quote("Created by command:"), quote(" ".join(sys.argv[:]))))
 
         tag_msg = "Tagging package [%s] version [%s] in directory [%s]." % \
                 (self.project_name, new_version_w_suffix,


### PR DESCRIPTION
This will create description as:

    Automatic commit of package [tito] release [0.6.9-1].
    
    Created by command:
    
    /usr/bin/tito tag

It use the feature of git-commit that additional -m option are used as next paragraph.

This can help newbies to identify tool and process how tagging was actually done (for example usage of --keep-version).