### PR TITLE
Work around `dnf` issues and install builddep for Rawhide

### DIFF
--- a/hacking/titotest-fedora-rawhide/Dockerfile
+++ b/hacking/titotest-fedora-rawhide/Dockerfile
@@ -4,8 +4,12 @@ FROM fedora:rawhide
 # http://jumanjiman.github.io/
 MAINTAINER Paul Morgan <jumanjiman@gmail.com>
 
+# Run an update to work around https://bugzilla.redhat.com/show_bug.cgi?id=1409590
+# TODO: remove this once the Rawhide base image is updated
+RUN dnf -y update
 # Install build dependencies.
 RUN dnf -y install \
+    'dnf-command(builddep)' \
     git-annex \
     python-devel \
     python-mock \


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/dgoodwin/tito/issues/247 
Rawhide tests run fine now, with the one test failure being 
```
======================================================================
FAIL: test_conformance (unit.pep8_tests.TestPep8)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sandbox/test/unit/pep8_tests.py", line 70, in test_conformance
    self.fail("Found PEP8 errors that may break your code in Python 3:\n%s" % output)
AssertionError: Found PEP8 errors that may break your code in Python 3:
1       E731 do not assign a lambda expression, use a def
-------------------- >> begin captured stdout << ---------------------
Testing in: /home/sandbox/test/unit/../..
/home/sandbox/test/unit/../../src/tito/common.py:218:9: E731 do not assign a lambda expression, use a def

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
```

@dgoodwin 