### PR TITLE
Use `def` instead of a lambda for function assignment

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -215,7 +215,8 @@ def _out(msgs, prefix, color_func, stream=sys.stdout):
 
     user_conf = read_user_config()
     if 'COLOR' in user_conf and (user_conf['COLOR'] == '0' or user_conf['COLOR'].lower() == 'false'):
-        color_func = lambda x: x
+        def color_func(x):
+            return x
 
     if isinstance(msgs, list):
         first_line = msgs.pop(0)


### PR DESCRIPTION
Using `def` instead of `x = lambda...` satisfies the PEP8 E731 warning.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@dgoodwin all tests now pass