### PR TITLE
Collapse tagger class selection logic

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -640,15 +640,8 @@ class TagModule(BaseCliModule):
             debug("block_tagging defined in tito.props")
             error_out("Tagging has been disabled in this git branch.")
 
-        tagger_class = None
-        if self.options.use_version:
-            tagger_class = get_class_by_name("tito.tagger.ForceVersionTagger")
-        elif self.config.has_option("buildconfig", "tagger"):
-            tagger_class = get_class_by_name(self.config.get("buildconfig",
-                "tagger"))
-        else:
-            tagger_class = get_class_by_name(self.config.get(
-                BUILDCONFIG_SECTION, DEFAULT_TAGGER))
+        tagger_class = get_class_by_name(self.config.get(
+            BUILDCONFIG_SECTION, DEFAULT_TAGGER))
         debug("Using tagger class: %s" % tagger_class)
 
         tagger = tagger_class(config=self.config,


### PR DESCRIPTION
In 26b02a7, the utility of the `ForceVersionTagger` was merged with the
base `VersionTagger`, so it is no longer necessary to ever explicitly
invoke the `ForceVersionTagger` class. Furthermore, the `elif` and
`else` branches of the decision tree for the tagger class were identical
in the previous implementation, so they were collapsed as well. The
remaining tagger class assignment is a simple query of the `tito.props`
file.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>