### PR TITLE
Added an option to not escalate privileges on `tito build --install`

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -307,6 +307,10 @@ class BuildModule(BaseCliModule):
                 action="store_true", default=False,
                 help="Install any binary rpms being built. (WARNING: " +
                     "uses sudo rpm -Uvh --force)")
+        self.parser.add_option("--no-sudo", dest="escalate",
+                action="store_false", default=True,
+                help="Don't escalate privileges when installing. Use when " +
+                "running this command with required privileges.")
         self.parser.add_option("--dist", dest="dist", metavar="DISTTAG",
                 help="Dist tag to apply to srpm and/or rpm. (i.e. .el5)")
 

--- a/tito.8.asciidoc
+++ b/tito.8.asciidoc
@@ -145,6 +145,9 @@ Install any binary RPMs being built.
 
 WARNING: uses `sudo rpm -Uvh --force`
 
+--no-sudo::
+Don't escalate privileges when installing. Use when running this command with required privileges.
+
 --dist='DISTTAG'::
 Apply 'DISTTAG' to srpm and/or rpm. (e.g., ".el5")
 

--- a/tito.8.asciidoc
+++ b/tito.8.asciidoc
@@ -90,6 +90,9 @@ spec file to tag package.
 --use-version='USE_VERSION'::
 Update the spec file with the specified version.
 
+--use-release='USE_RELEASE'::
+Update the spec file with the specified release.
+
 --no-auto-changelog::
 Don't automatically create a changelog entry for this
 tag if none is found


### PR DESCRIPTION
When using `tito build --install` on a system without `sudo`, such as
inside of a Linux container build, the current implementation fails.
Furthermore, if the user is running `tito build --install` with the
correct level of privilege, it is not necessary to escalate privileges
further for the installation step.

This patch adds the `--dont-escalate-privileges` flag to `tito build`
and defaults it to `True`, which keeps the behavior backwards compat-
ible. Users will want to use this flag when building RPMs inside of a
container or when running `tito build` with the requisite permissions
for installing in the first place.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>