### PR TITLE
Flush output buffers

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -226,6 +226,8 @@ def _out(msgs, prefix, color_func, stream=sys.stdout):
     else:
         print(color_func(fmt % {'prefix': prefix, 'msg': msgs}), file=stream)
 
+    stream.flush()
+
 
 def error_out(error_msgs, die=True):
     """


### PR DESCRIPTION
When using `$DEBUG=1`, often the output from different parts of `tito`
that output to different streams (for instance, `stderr` and `stdout`)
appears in the terminal in a garbled order. Furthermore, the stacktraces
generated by the Python interpreter are out of order with the output
from the `tito` process and often fragmented. By flushing the output
buffers on `tito.common._out()` we should be able to work around this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>