### PR TITLE
Updated some debugging statements

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -248,7 +248,7 @@ class BuilderBase(object):
             '--define "_binary_filedigest_algorithm md5" %s %s %s %s '
             '-ba %s' % (rpmbuild_options,
                 self._get_rpmbuild_dir_options(), define_dist, self._get_clean_option(), self.spec_file))
-        debug(cmd)
+        debug("Building RPMs with: \n%s".format(cmd))
         try:
             output = run_command_print(cmd)
         except (KeyboardInterrupt, SystemExit):

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -413,12 +413,6 @@ def run_command(command, print_on_success=False):
     If command fails, print status code and command output.
     """
     (status, output) = getstatusoutput(command)
-
-    # ISSUE 253 - allow for better debug output
-    debug("Command: %s" % command)
-    debug("Status code: %s" % status)
-    debug("Command output: %s\n" % output)
-
     if status > 0:
         msgs = [
             "Error running command: %s\n" % command,
@@ -431,6 +425,11 @@ def run_command(command, print_on_success=False):
         print("Command: %s\n" % command)
         print("Status code: %s\n" % status)
         print("Command output: %s\n" % output)
+    else:
+        debug("Command: %s" % command)
+        debug("Status code: %s" % status)
+        debug("Command output: %s\n" % output)
+
     return output
 
 


### PR DESCRIPTION
Improved debugging for RPM build step

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Print command debugging information only once

When debugging is turned on and a command is run that fails or with
`print_on_success` on, the output for the command execution ends up
being printed twice. This change ensures that only one set of output
is printed at any point.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---