### PR TITLE
Added `--quiet` and `--verbose` to `tito build`

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -77,6 +77,9 @@ class BuilderBase(object):
         self.scl = self._get_optional_arg(args, 'scl', [None])[0] or \
                 self._get_optional_arg(kwargs, 'scl', '')
 
+        self.quiet = self._get_optional_arg(kwargs, 'quiet', False)
+        self.verbose = self._get_optional_arg(kwargs, 'verbose', False)
+
         rpmbuildopts = self._get_optional_arg(args, 'rpmbuild_options', None)
         if rpmbuildopts:
             self.rpmbuild_options = ' '.join(rpmbuildopts)
@@ -232,6 +235,14 @@ class BuilderBase(object):
             return "--noclean"
         return "--clean"
 
+    def _get_verbosity_option(self):
+        if self.quiet:
+            return "--quiet"
+        elif self.verbose:
+            return "--verbose"
+        else:
+            return ""
+
     def rpm(self):
         """ Build an RPM. """
         self._create_build_dirs()
@@ -246,8 +257,9 @@ class BuilderBase(object):
 
         cmd = ('rpmbuild --define "_source_filedigest_algorithm md5"  '
             '--define "_binary_filedigest_algorithm md5" %s %s %s %s '
-            '-ba %s' % (rpmbuild_options,
-                self._get_rpmbuild_dir_options(), define_dist, self._get_clean_option(), self.spec_file))
+            '-ba %s %s' % (rpmbuild_options,
+                self._get_rpmbuild_dir_options(), define_dist, self._get_clean_option(), self.spec_file,
+                self._get_verbosity_option()))
         debug("Building RPMs with: \n%s".format(cmd))
         try:
             output = run_command_print(cmd)

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -468,7 +468,7 @@ class Builder(ConfigObject, BuilderBase):
         Can be overridden when custom taggers override counterpart,
         tito.VersionTagger._get_tag_for_version().
         """
-        return "%s-%s".format(self.project_name, version)
+        return "{}-{}".format(self.project_name, version)
 
     def tgz(self):
         """

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -249,17 +249,19 @@ class BuilderBase(object):
         if not self.ran_tgz:
             self.tgz()
 
-        define_dist = ""
-        if self.dist:
-            define_dist = "--define 'dist %s'" % self.dist
-
-        rpmbuild_options = self.rpmbuild_options + self._scl_to_rpmbuild_option()
-
-        cmd = ('rpmbuild --define "_source_filedigest_algorithm md5"  '
-            '--define "_binary_filedigest_algorithm md5" %s %s %s %s '
-            '-ba %s %s' % (rpmbuild_options,
-                self._get_rpmbuild_dir_options(), define_dist, self._get_clean_option(), self.spec_file,
-                self._get_verbosity_option()))
+        cmd = 'rpmbuild {}'.format(
+            " ".join([
+                '--define "_source_filedigest_algorithm md5"',
+                '--define "_binary_filedigest_algorithm md5"',
+                self.rpmbuild_options,
+                self._scl_to_rpmbuild_option(),
+                self._get_rpmbuild_dir_options(),
+                "--define 'dist {}'".format(self.dist) if self.dist else "",
+                self._get_clean_option(),
+                self._get_verbosity_option(),
+                '-ba {}'.format(self.spec_file),
+            ])
+        )
         debug("Building RPMs with: \n%s".format(cmd))
         try:
             output = run_command_print(cmd)

--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -332,6 +332,11 @@ class BuildModule(BaseCliModule):
                 help="Custom arguments specific to a particular builder."
                     " (key=value)")
 
+        self.parser.add_option("--quiet", dest="quiet", action="store_true",
+                help="Suppress output from the build process.")
+        self.parser.add_option("--verbose", dest="verbose", action="store_true",
+                help="Expose more output from the build process.")
+
         self.parser.add_option("--rpmbuild-options", dest='rpmbuild_options',
                 default='',
                 metavar="OPTIONS", help="Options to pass to rpmbuild.")
@@ -372,6 +377,8 @@ class BuildModule(BaseCliModule):
             error_out("Cannot combine --srpm and --rpm")
         if self.options.test and self.options.tag:
             error_out("Cannot build test version of specific tag.")
+        if self.options.quiet and self.options.verbose:
+            error_out("Cannot set --quiet and --verbose at the same time.")
 
     def _parse_builder_args(self):
         """

--- a/tito.8.asciidoc
+++ b/tito.8.asciidoc
@@ -175,6 +175,12 @@ Custom arguments specific to a particular builder. (key=value)
 Build package for software collection. This is mostly useful for building
 src.rpm, because for rpm you want to define this option for specific tag in tito.props
 
+--quiet::
+Suppress output from the build process.
+
+--verbose::
+Expose more output from the build process.
+
 
 `tito release [options] TARGETS`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Refactor `rpmbuild` invocation for readability

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Added `--quiet` and `--verbose` to `tito build`

The current output levels from `tito build` are both very verbose in the
case that nothing goes wrong and often missing full context when some-
thing does go wrong. By exposing `--quiet` and `--verbose`, the build
process should be able to modulate the amount of output coming from the
internal process and from `rpmbuild`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---