### PR TITLE
Refactored version->tag mapping logic in Tagger

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -452,7 +452,7 @@ class Builder(ConfigObject, BuilderBase):
         """
         Determine what the tag will look like for a given version.
         Can be overridden when custom taggers override counterpart,
-        tito.VersionTagger._get_new_tag().
+        tito.VersionTagger._get_tag_for_version().
         """
         return "%s-%s".format(self.project_name, version)
 

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -226,7 +226,8 @@ def _out(msgs, prefix, color_func, stream=sys.stdout):
     else:
         print(color_func(fmt % {'prefix': prefix, 'msg': msgs}), file=stream)
 
-    stream.flush()
+    if 'DEBUG' in os.environ and callable(getattr(stream, 'flush', None)):
+        stream.flush()
 
 
 def error_out(error_msgs, die=True):


### PR DESCRIPTION
Only flush output stream if flushing is supported

While file handles support the `.flush()` method, some of the more
UNIX-ey pipes and tees do not. We should try to `.flush()` when we
can, but not bother when we can't.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Added support for choosing platforms for tests

Running the entire suite of containerized tests across all of the
platforms that are supported takes quite a while, especially if the
container images need to be built. Now, the platforms that are to be
tested can be specified with `$PY2_DISTROS` and `$PY3_DISTROS`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Refactored version->tag mapping logic in Tagger

While the `tito.VersionTagger._get_new_tag()` method encapsulated some
of the version->tag mapping logic, other areas in the `VersionTagger`
used their own logic to do the mapping. This commit ensures that this
mapping happens in one place, which allows for custom implementations
to override the behavior simply.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
