### PR TITLE
Updates to the MANIFEST and `tito build --quiet`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,7 @@ include AUTHORS
 include LICENSE
 include MANIFEST.in
 include COPYING
-include README.mkd
-include *.5
+include README.md
 include *.asciidoc
 include doc/*
 recursive-include bin *.*

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -262,7 +262,7 @@ class BuilderBase(object):
                 '-ba {}'.format(self.spec_file),
             ])
         )
-        debug("Building RPMs with: \n%s".format(cmd))
+        debug("Building RPMs with: \n{}".format(cmd))
         try:
             output = run_command_print(cmd)
         except (KeyboardInterrupt, SystemExit):

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -236,9 +236,7 @@ class BuilderBase(object):
         return "--clean"
 
     def _get_verbosity_option(self):
-        if self.quiet:
-            return "--quiet"
-        elif self.verbose:
+        if self.verbose:
             return "--verbose"
         else:
             return ""
@@ -262,9 +260,11 @@ class BuilderBase(object):
                 '-ba {}'.format(self.spec_file),
             ])
         )
-        debug("Building RPMs with: \n{}".format(cmd))
         try:
-            output = run_command_print(cmd)
+            if self.quiet:
+                output = run_command(cmd)
+            else:
+                output = run_command_print(cmd)
         except (KeyboardInterrupt, SystemExit):
             print("")
             exit(1)

--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -362,6 +362,8 @@ class BuildModule(BaseCliModule):
             'auto_install': self.options.auto_install,
             'rpmbuild_options': self.options.rpmbuild_options,
             'scl': self.options.scl,
+            'quiet': self.options.quiet,
+            'verbose': self.options.verbose,
         }
 
         builder = create_builder(package_name, build_tag,


### PR DESCRIPTION
Achieve quiet output from `rpmbuild` without passing `--quiet`

The output from `rpmbuild` is necessary to capture for determining which
artifacts were created as part of the build, so we cannot achieve quiet
output from `tito build --quiet` by passing `--quiet` to `rpmbuild` as
well. Instead we just don't print the output from the command unless it
fails.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Update the MANIFEST.in

No `README.mkd` file exists, but `README.md` does. No files ending in
`.5` exist, but some manpages that end in `.5.asciidoc` do.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Correctly pass verbosity options through the builder CLI

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Use correct print-formatting directive in debugging

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
