### PR TITLE
Iron out Python 2.6 incompatibilities for CentOS 6

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -232,8 +232,13 @@ class BuilderBase(object):
     # Assume that if tito's --no-cleanup option is set, also disable %clean in rpmbuild:
     def _get_clean_option(self):
         if self.no_cleanup:
-            return "--noclean"
-        return "--clean"
+            output = run_command('rpmbuild --help')
+            if '--noclean' in output:
+                return "--noclean"
+            else:
+                return ""
+        else:
+            return "--clean"
 
     def _get_verbosity_option(self):
         if self.verbose:

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -247,17 +247,17 @@ class BuilderBase(object):
         if not self.ran_tgz:
             self.tgz()
 
-        cmd = 'rpmbuild {}'.format(
+        cmd = 'rpmbuild {0}'.format(
             " ".join([
                 '--define "_source_filedigest_algorithm md5"',
                 '--define "_binary_filedigest_algorithm md5"',
                 self.rpmbuild_options,
                 self._scl_to_rpmbuild_option(),
                 self._get_rpmbuild_dir_options(),
-                "--define 'dist {}'".format(self.dist) if self.dist else "",
+                "--define 'dist {0}'".format(self.dist) if self.dist else "",
                 self._get_clean_option(),
                 self._get_verbosity_option(),
-                '-ba {}'.format(self.spec_file),
+                '-ba {0}'.format(self.spec_file),
             ])
         )
         try:
@@ -468,7 +468,7 @@ class Builder(ConfigObject, BuilderBase):
         Can be overridden when custom taggers override counterpart,
         tito.VersionTagger._get_tag_for_version().
         """
-        return "{}-{}".format(self.project_name, version)
+        return "{0}-{1}".format(self.project_name, version)
 
     def tgz(self):
         """

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -718,7 +718,7 @@ def munge_setup_macro(fullname, line):
         if "%autosetup" in macro:
             args_match = re.search(r'(.+?)\s+-p[01]\s+\S+(.*)', args)
             if not args_match:
-                macro = "{} -p1".format(macro)
+                macro = "{0} -p1".format(macro)
 
         return macro
     return None

--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -556,7 +556,7 @@ class VersionTagger(ConfigObject):
         suffix = ""
         if self.config.has_option(BUILDCONFIG_SECTION, "tag_suffix"):
             suffix = self.config.get(BUILDCONFIG_SECTION, "tag_suffix")
-        return "{}{}".format(version, suffix)
+        return "{0}{1}".format(version, suffix)
 
     def _get_tag_for_version(self, version):
         """
@@ -564,7 +564,7 @@ class VersionTagger(ConfigObject):
         Can be overridden when custom taggers override counterpart,
         tito.Builder._get_tag_for_version().
         """
-        return "{}-{}".format(self.project_name, version)
+        return "{0}-{1}".format(self.project_name, version)
 
     def _update_version_file(self, new_version):
         """

--- a/test/functional/singleproject_tests.py
+++ b/test/functional/singleproject_tests.py
@@ -126,7 +126,7 @@ class SingleProjectTests(TitoGitTestFixture):
 
         with Capture(silent=True) as capture:
             self.assertRaises(SystemExit, tito, "tag --accept-auto-changelog")
-        self.assertIn("Unknown placeholder 'ultimate_answer' in tag_commit_message_format",
+        self.assertTrue("Unknown placeholder 'ultimate_answer' in tag_commit_message_format" in
                       capture.err)
 
     def test_tag_with_custom_message_containing_quotes(self):


### PR DESCRIPTION
Use `.assertTrue()` instead of `.assertIn()`

CentOS 6 only has Python 2.6 available, on which the unit testing
frameworks do not expose a `.assertIn()` helper method. Instead, we can
use `.assertTrue(x in y)`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Only use `rpmbuild --noclean` if it is supported

CentOS 6 only has rpmbuild 4.8 available, on which the `--noclean` option
is not present. We should only pass `--noclean` to `rpmbuild` when we
can determine that it is supported.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Explicitly define indicies in formatting statements

Python 2.6 is the latest Python version available on CentOS 6. In Python
2.6, the newer formatting statements must have indexed formatting
specifiers, so you must write

    "{0}{1}".format(foo, bar)

instead of:

    "{}{}".format(foo, bar)

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
