### PR TITLE
Parse options in `tito init`

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -683,6 +683,7 @@ class InitModule(BaseCliModule):
         # DO NOT CALL BaseCliModule.main(self)
         # we are initializing tito to work in this module and
         # calling main will result in a configuration error.
+        (self.options, self.args) = self.parser.parse_args(argv)
         should_commit = False
 
         rel_eng_dir = os.path.join(find_git_root(), '.tito')


### PR DESCRIPTION
Previously, the `optparse` option parsing was not being done in the
call to `tito init`, which led to CLI invocations that used `--help`
not getting the helptext and instead getting the normal output of
`tito init`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>