### PR TITLE
workaround git diff on fedora for rename patches

### DIFF
--- a/bin/generate-patches.pl
+++ b/bin/generate-patches.pl
@@ -124,13 +124,13 @@ while (@end_version > @start_version) {
 
 for (my $i = 0; $i < @path - 1; $i++) {
 	my $patch_name = "$path[$i]-to-$path[$i + 1].patch";
-	system "git diff --relative $path[$i]..$path[$i + 1] > $target_directory/$patch_name";
+	system "git diff --no-renames --relative $path[$i]..$path[$i + 1] > $target_directory/$patch_name";
 	print "$patch_name\n";
 }
 
 if (defined $commit_id) {
 	my $patch_name = "$path[$#path]-to-$package-git-$commit_id.patch";
-	system "git diff --relative $path[$#path]..$commit_id > $target_directory/$patch_name";
+	system "git diff --no-renames --relative $path[$#path]..$commit_id > $target_directory/$patch_name";
 	if (-s "$target_directory/$patch_name") {
 		print "$patch_name\n";
 	} else {


### PR DESCRIPTION
On Fedora 25 (maybe 24 too), git diff creates patches for renamed files in format which patch tool in version contained in RHEL 6 can't apply properly. This patch works around this problem.

git-core-2.9.3-2.fc25.x86_64
patch-2.6-6.el6.x86_64