### PR TITLE
VersionTagger support for custom tag format

### DIFF
--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -468,6 +468,7 @@ class VersionTagger(ConfigObject):
                '[%(name)s] %(release_type)s [%(version)s].')
         if self.config.has_option(BUILDCONFIG_SECTION, "tag_commit_message_format"):
             fmt = self.config.get(BUILDCONFIG_SECTION, "tag_commit_message_format")
+        new_version_w_suffix = self._get_suffixed_version(new_version)
         try:
             msg = fmt % {
                 'name': self.project_name,
@@ -482,11 +483,11 @@ class VersionTagger(ConfigObject):
         run_command('git commit -m {0} -m {1} -m {2}'.format(
             quote(msg), quote("Created by command:"), quote(" ".join(sys.argv[:]))))
 
+        new_tag = self._get_new_tag(new_version)
         tag_msg = "Tagging package [%s] version [%s] in directory [%s]." % \
-                (self.project_name, new_version_w_suffix,
+                (self.project_name, new_tag,
                         self.relative_project_dir)
 
-        new_tag = self._get_new_tag(new_version)
         run_command('git tag -m "%s" %s' % (tag_msg, new_tag))
         print
         info_out("Created tag: %s" % new_tag)
@@ -547,9 +548,17 @@ class VersionTagger(ConfigObject):
             email = None
         return (name, email)
 
-    def _get_new_tag(self, new_version):
+    def _get_new_tag(self, version_and_release):
         """ Returns the actual tag we'll be creating. """
-        return self._get_tag_for_version(self._get_suffixed_version(new_version))
+        suffixed_version = self._get_suffixed_version(self._get_version(version_and_release))
+        release = self._get_release(version_and_release)
+        return self._get_tag_for_version(suffixed_version, release)
+
+    def _get_release(self, version_and_release):
+        return version_and_release.split('-')[-1]
+
+    def _get_version(self, version_and_release):
+        return version_and_release.split('-')[-2]
 
     def _get_suffixed_version(self, version):
         """ If global config specifies a tag suffix, use it """
@@ -558,13 +567,23 @@ class VersionTagger(ConfigObject):
             suffix = self.config.get(BUILDCONFIG_SECTION, "tag_suffix")
         return "{0}{1}".format(version, suffix)
 
-    def _get_tag_for_version(self, version):
+    def _get_tag_for_version(self, version, release=''):
         """
         Determine what the tag will look like for a given version.
         Can be overridden when custom taggers override counterpart,
         tito.Builder._get_tag_for_version().
         """
-        return "{0}-{1}".format(self.project_name, version)
+        if self.config.has_option(BUILDCONFIG_SECTION, "tag_format"):
+            tag_format = self.config.get(BUILDCONFIG_SECTION, "tag_format")
+        else:
+            tag_format = "{component}-{version}-{release}"
+        kwargs = {
+            'component': self.project_name,
+            'version': version,
+            'release': release
+        }
+        # Strip extra dashes if one of the params is empty
+        return tag_format.format(**kwargs).strip('-')
 
     def _update_version_file(self, new_version):
         """

--- a/test/functional/custom_tag_tests.py
+++ b/test/functional/custom_tag_tests.py
@@ -1,0 +1,87 @@
+import os
+import tempfile
+import unittest
+
+from tito.cli import CLI
+from tito.common import run_command
+from tito.compat import getoutput
+
+TEST_SPEC = """
+Name:           hello_tito
+Version:        0.1.7
+Release:        1%{?dist}
+Summary:        testing package
+
+License:        Public Domain
+Source0:        hello_tito-%{version}.tar.gz
+
+%description
+
+
+%prep
+%autosetup
+
+
+%build
+
+%install
+
+%files
+
+%changelog
+"""
+
+
+def tito(argstring):
+    """ Run Tito from source with given arguments. """
+    return CLI().main(argstring.split(' '))
+
+
+class VersionTaggerTest(unittest.TestCase):
+    """
+    Test 'VersionTagger' class.
+    """
+
+    def setUp(self):
+        self.repo_dir = tempfile.mkdtemp("-titouserspecifiedtag")
+        print("Testing in: %s" % self.repo_dir)
+        os.chdir(self.repo_dir)
+
+        self.full_pkg_dir = os.path.join(self.repo_dir, "hello_tito")
+        run_command('mkdir -p %s' % self.full_pkg_dir)
+
+        # Initialize the repo:
+        os.chdir(self.full_pkg_dir)
+        run_command('git init')
+
+        # Next we tito init:
+        tito("init")
+        run_command('sed -i "s;tagger.*;tagger = tito.tagger.VersionTagger;g" .tito/tito.props')
+        run_command('echo "offline = true" >> .tito/tito.props')
+        run_command('echo "tag_format = {component}-v{version}" >> .tito/tito.props')
+        run_command('git add .tito/tito.props')
+        run_command("git commit -m 'set offline in tito.props'")
+
+        # Init RPM package
+        self.create_rpm_package()
+
+        # Run tito tag
+        tito("tag --accept-auto-changelog")
+
+    def write_file(self, path, contents):
+        out_f = open(path, 'w')
+        out_f.write(contents)
+        out_f.close()
+
+    def create_rpm_package(self):
+        os.chdir(self.full_pkg_dir)
+        self.write_file(os.path.join(self.full_pkg_dir, 'hello_tito.spec'), TEST_SPEC)
+        run_command('git add hello_tito.spec')
+        run_command("git commit -m 'add spec file'")
+
+    def test_tag(self):
+        """
+        Check that the tag is correct
+        """
+        latest_tag = getoutput("git describe --abbrev=0 --tags")
+        assert latest_tag == 'hello_tito-v0.1.8'

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -80,6 +80,10 @@ This option is used control the text of git commit message that is used when
 new tag is generated. You can use "%(name)s", "%(release_type)s" and
 "%(version)s" placeholders.
 
+tag_format::
+This option controls the format used in VersionTagger. If not specified
+default format would be '{component}-{version}-{release}'. It won't affect
+other taggers.
 
 KOJI and COPR
 -------------


### PR DESCRIPTION
`VersionTagger` creates a long tag - e.g. `project-1.0-3` - but its not required for most projects. This PR adds a new tagger which creates `<version>` tag, which would fit most projects.

TODO:
 * [x] Convert this to a config setting with a string to format
 * [x] Update documentation
 * [x] Add tests