### PR TITLE
Custom tag support in tito release

### DIFF
--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -257,7 +257,7 @@ class VersionTagger(ConfigObject):
                         write(fd, "\n")
                 else:
                     if old_version is not None:
-                        last_tag = self._get_tag_for_version(old_version)
+                        last_tag = self._get_new_tag(old_version)
                         output = self._generate_default_changelog(last_tag)
                     else:
                         output = self._new_changelog_msg

--- a/test/functional/custom_tag_tests.py
+++ b/test/functional/custom_tag_tests.py
@@ -65,8 +65,8 @@ class VersionTaggerTest(unittest.TestCase):
         # Init RPM package
         self.create_rpm_package()
 
-        # Run tito tag
-        tito("tag --accept-auto-changelog")
+        # Run tito release
+        tito("tag release --accept-auto-changelog")
 
     def write_file(self, path, contents):
         out_f = open(path, 'w')


### PR DESCRIPTION
A follow-up for https://github.com/dgoodwin/tito/pull/277 - `tito release` should also understand the new tag format