### PR TITLE
force VersionTagger when tito tag is called with --use-version

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -653,8 +653,11 @@ class TagModule(BaseCliModule):
             debug("block_tagging defined in tito.props")
             error_out("Tagging has been disabled in this git branch.")
 
-        tagger_class = get_class_by_name(self.config.get(
-            BUILDCONFIG_SECTION, DEFAULT_TAGGER))
+        if self.options.use_version:
+            tagger_class = get_class_by_name("tito.tagger.VersionTagger")
+        else:
+            tagger_class = get_class_by_name(self.config.get(
+                BUILDCONFIG_SECTION, DEFAULT_TAGGER))
         debug("Using tagger class: %s" % tagger_class)
 
         tagger = tagger_class(config=self.config,


### PR DESCRIPTION
In 6b57b0b, the code that checked wither we used `--use-version` was removed, because both `VersionTagger` and `ForceVersionTagger` are identical now. However, this breaks setups where the default tagger is `ReleaseTagger` but the user still wants to use `--use-version` sometimes.

Thus let's force `VersionTagger` when `--use-version` was given and only use whatever is in `tito.props` when it was not.

Fixes: #274

Signed-off-by: Evgeni Golov <egolov@redhat.com>