### PR TITLE
Format package list more cleanly

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -290,7 +290,7 @@ class BuilderBase(object):
         self.artifacts.extend(files_written)
 
         print
-        info_out("Successfully built: %s" % ' '.join(files_written))
+        info_out("Successfully built: %s" % '\n\t- '.join(files_written))
 
     def _scl_to_rpmbuild_option(self):
         """ Returns rpmbuild option which disable or enable SC and print warning if needed """


### PR DESCRIPTION
When building a large number of packages, the current output from tito
will place all of them on one very long line, which makes it hard to
read. Instead, we should place them on separate lines to format them
more like a list.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @dgoodwin PTAL