### PR TITLE
ReleaseTagger --use-version support

### DIFF
--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -654,7 +654,10 @@ class ReleaseTagger(VersionTagger):
         Tag a new release of the package. (i.e. x.y.z-r+1)
         """
         self._make_changelog()
-        new_version = self._bump_version(release=True)
+        # the user might have passed --use-version
+        # so let's just bump the release if they did not
+        bump_release = not hasattr(self, '_use_version')
+        new_version = self._bump_version(release=bump_release)
 
         self._check_tag_does_not_exist(self._get_new_tag(new_version))
         self._update_changelog(new_version)

--- a/test/functional/multiproject_tests.py
+++ b/test/functional/multiproject_tests.py
@@ -128,6 +128,14 @@ class MultiProjectTests(TitoGitTestFixture):
         new_ver = get_latest_tagged_version(TEST_PKG_2)
         self.assertTrue(release_bumped(start_ver, new_ver))
 
+    def test_release_tagger_use_version(self):
+        os.chdir(os.path.join(self.repo_dir, 'pkg2'))
+        start_ver = get_latest_tagged_version(TEST_PKG_2)
+        tito('tag --debug --accept-auto-changelog --use-version 1.3.37')
+        new_ver = get_latest_tagged_version(TEST_PKG_2)
+        self.assertFalse(release_bumped(start_ver, new_ver))
+        self.assertEquals(new_ver, "1.3.37-1")
+
     def test_build_tgz(self):
         os.chdir(os.path.join(self.repo_dir, 'pkg1'))
         artifacts = tito('build --tgz')

--- a/test/functional/multiproject_tests.py
+++ b/test/functional/multiproject_tests.py
@@ -128,6 +128,12 @@ class MultiProjectTests(TitoGitTestFixture):
         new_ver = get_latest_tagged_version(TEST_PKG_2)
         self.assertTrue(release_bumped(start_ver, new_ver))
 
+    def test_release_tagger_use_release(self):
+        os.chdir(os.path.join(self.repo_dir, 'pkg2'))
+        tito('tag --debug --accept-auto-changelog --use-release 42')
+        new_ver = get_latest_tagged_version(TEST_PKG_2)
+        self.assertEquals(new_ver.split('-')[-1], "42")
+
     def test_release_tagger_use_version(self):
         os.chdir(os.path.join(self.repo_dir, 'pkg2'))
         start_ver = get_latest_tagged_version(TEST_PKG_2)


### PR DESCRIPTION
This adds `--use-version` support to `ReleaseTagger` as discussed in #274 and #283.
Basically it just checks if the user passed `--use-version` and calls `_bump_version` with either `release=True` or `release=False` based on that.