### PR TITLE
use LC_ALL=C.UTF-8 rather than plain C

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -442,7 +442,7 @@ def run_command_print(command):
     """
     output = []
     env = os.environ.copy()
-    env['LC_ALL'] = 'C'
+    env['LC_ALL'] = 'C.UTF-8'
     p = subprocess.Popen(shlex.split(command),
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env,
         universal_newlines=True)


### PR DESCRIPTION
addressing:
Python runtime initialized with LC_CTYPE=C (a locale with default ASCII encoding), which may cause Unicode compatibility problems. Using C.UTF-8, C.utf8, or UTF-8 (if available) as alternative Unicode-compatible locales is recommended.