### PR TITLE
Don't append 'None' to Release line with no '%{?dist}' part

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -694,7 +694,7 @@ def munge_specfile(spec_file, commit_id, commit_count, fullname=None, tgz_filena
                 m.group(2),
                 commit_count,
                 sha,
-                m.group(3),
+                m.group(3) or '',
             ))
             continue
 

--- a/test/unit/common_tests.py
+++ b/test/unit/common_tests.py
@@ -389,6 +389,23 @@ class SpecTransformTest(unittest.TestCase):
 
         self.assertEquals("%%setup -q -n %s\n" % fullname, output[1])
 
+    def test_transform_no_dist_tag(self):
+        simple_spec = dedent("""
+        Release: 1
+        Source: hello-1.0.0.tar.gz
+        """)
+        with open(self.spec_file, 'w') as f:
+            f.write(simple_spec)
+
+        sha = "acecafe"
+        commit_count = 5
+        munge_specfile(self.spec_file, sha, commit_count)
+        output = open(self.spec_file, 'r').readlines()
+
+        self.assertEquals(3, len(output))
+        self.assertEquals("Release: 1.git.%s.%s\n" % (commit_count, sha), output[1])
+        self.assertEquals("Source: hello-1.0.0.tar.gz\n", output[2])
+
 
 class VersionMathTest(unittest.TestCase):
     def test_increase_version_minor(self):


### PR DESCRIPTION
When doing --test build, if the spec file 'Release' line contains no '%{?dist}' part, tito will append 'None' at the end of the release option. This change makes sure nothing is added when this part is not present in the line.