### PR TITLE
Fix a race condition when /tmp/tito doesn't exist

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -16,6 +16,7 @@ Tito's Command Line Interface
 
 import sys
 import os
+import errno
 
 from optparse import OptionParser, SUPPRESS_HELP
 
@@ -237,10 +238,6 @@ class BaseCliModule(object):
             default=False)
 
         default_output_dir = lookup_build_dir(self.user_config)
-        if not os.path.exists(default_output_dir):
-            print("Creating output directory: %s" % default_output_dir)
-            run_command("mkdir %s" % default_output_dir)
-
         self.parser.add_option("-o", "--output", dest="output_dir",
                 metavar="OUTPUTDIR", default=default_output_dir,
                 help="Path to write temp files, tarballs and rpms to. "
@@ -255,6 +252,14 @@ class BaseCliModule(object):
         if len(argv) < 1:
             print(self.parser.error("Must supply an argument. "
                 "Try -h for help."))
+
+        build_dir = os.path.normpath(os.path.abspath(self.options.output_dir))
+        print("Creating output directory: %s" % build_dir)
+        try:
+            os.makedirs(build_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
     def load_config(self, package_name, build_dir, tag):
         self.config = ConfigLoader(package_name, build_dir, tag).load()


### PR DESCRIPTION
When doing concurrent build, if `/tmp/tito` doesn't exist, even if different output
directories for different builds are specified,
tito will fail because tito processes are trying to create
`/tmp/tito` at the time that directory doesn't exist.

Here is the stack trace when this issue occurs:

```
06:42:15 [el7] + tito build --test --rpm --output=artifacts/el7 --builder=tito.builder.MockBuilder --arg=mock=eng-rhel-7-candidate-x86_64
06:42:16 [el7] ERROR: Error running command: mkdir /tmp/tito
06:42:16 [el7]
06:42:16 [el7] Status code: 256
06:42:16 [el7]
06:42:16 [el7] Command output: mkdir: cannot create directory '/tmp/tito': File exists
06:42:16 [el7]
06:42:16 [el7] Creating output directory: /tmp/tito
06:42:16 [el7] Traceback (most recent call last):
06:42:16 [el7]   File "/usr/bin/tito", line 23, in <module>
06:42:16 [el7]     CLI().main(sys.argv[1:])
06:42:16 [el7]   File "/usr/lib/python2.7/site-packages/tito/cli.py", line 201, in main
06:42:16 [el7]     module = module_class()
06:42:16 [el7]   File "/usr/lib/python2.7/site-packages/tito/cli.py", line 298, in __init__
06:42:16 [el7]     BaseCliModule.__init__(self, "usage: %prog build [options]")
06:42:16 [el7]   File "/usr/lib/python2.7/site-packages/tito/cli.py", line 223, in __init__
06:42:16 [el7]     self._add_common_options()
06:42:16 [el7]   File "/usr/lib/python2.7/site-packages/tito/cli.py", line 242, in _add_common_options
06:42:16 [el7]     run_command("mkdir %s" % default_output_dir)
06:42:16 [el7]   File "/usr/lib/python2.7/site-packages/tito/common.py", line 426, in run_command
06:42:16 [el7]     raise RunCommandException(command, status, output)
06:42:16 [el7] tito.exception.RunCommandException: Error running
command: mkdir /tmp/tito
```

This change will make sure that the user defined output directory will
be created if the default output directory, `/tmp/tito`, is overridden by the '--output' option.