### PR TITLE
Encourage usage of git push --follow-tags

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -604,7 +604,7 @@ def check_tag_exists(tag, offline=False):
     upstream_tag_sha1 = get_remote_tag_sha1(tag)
     if upstream_tag_sha1 == "":
         error_out(["Tag does not exist in remote git repo: %s" % tag,
-            "You must tag, then git push and git push --tags"])
+            "You must tag, then git push --follow-tags"])
 
     debug("Remote tag SHA1: %s" % upstream_tag_sha1)
 

--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -493,7 +493,7 @@ class VersionTagger(ConfigObject):
         info_out("Created tag: %s" % new_tag)
         print("   View: git show HEAD")
         print("   Undo: tito tag -u")
-        print("   Push: git push origin && git push origin %s" % new_tag)
+        print("   Push: git push --follow-tags origin")
 
     def _check_tag_does_not_exist(self, new_tag):
         status, output = getstatusoutput(


### PR DESCRIPTION
git push knows --follow-tags option since 1.8.3 (released in April 2013). It pushes both new commits and tags associated with them (if any) in one transaction. It was introduced as preferred way of doing `git push && git push --tags`.

This commit changes user-visible messages to encourage people to use this option instead of old idiom.