### PR TITLE
Fixing remote_git_name

### DIFF
--- a/src/tito/release/distgit.py
+++ b/src/tito/release/distgit.py
@@ -49,7 +49,11 @@ class FedoraGitReleaser(Releaser):
         self.git_branches = \
             self.releaser_config.get(self.target, "branches").split(" ")
 
-        if self.config.has_option(self.target, "remote_git_name"):
+        # check .tito/releasers.conf
+        if self.releaser_config.has_option(self.target, "remote_git_name"):
+            overwrite_checkout = self.releaser_config.get(self.target, "remote_git_name")
+        # fallback to old, incorrect, location: .tito/packages/tito.props
+        elif self.config.has_option(self.target, "remote_git_name"):
             overwrite_checkout = self.config.get(self.target, "remote_git_name")
         else:
             overwrite_checkout = None

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -222,8 +222,10 @@ For example let say you have in releaser.conf:
  releaser = tito.release.DistGitReleaser
  branches = satellite-6.0-rhel-6
 +
-and then in package directory you can create tito.props with content:
+and then you can add remote_git_name:
  [git-sat]
+ releaser = tito.release.DistGitReleaser
+ branches = satellite-6.0-rhel-6
  remote_git_name = ruby193-rubygem-simple-navigation
 And it will push package into ruby193-rubygem-simple-navigation dist-git despite the
 fact that it is in /rubygem-simple-navigation directory. And project name (as taken


### PR DESCRIPTION
remote_git_name now works in releasers.conf as intended.