### PR TITLE
Fix chicken/egg problem with .spec files and includes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license='GPLv2+',
 
     package_dir={
-        'tito': 'src/tito',
+        '': 'src/',
     },
     packages=find_packages('src'),
     include_package_data=True,

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -197,6 +197,21 @@ class BuilderBase(object):
             mkdir_p(d)
         self._check_build_dirs_access(build_dirs)
 
+    def _copy_extra_sources(self):
+        """
+        Copy extra %{SOURCEX} files to the SOURCE folder.
+        """
+        with open(self.spec_file, 'r') as spec:
+            for line in spec.readlines():
+                match = re.match(r'SOURCE[1-9]\d*:(?P<src>.*)', line, re.I)
+                if match is None:
+                    continue
+
+                src = os.path.join(self.rpmbuild_sourcedir, self.tgz_dir, match.group('src').strip())
+                debug("Copying %s -> %s" % (src, self.rpmbuild_sourcedir))
+                shutil.copy(src, self.rpmbuild_sourcedir)
+
+
     def srpm(self, dist=None):
         """
         Build a source RPM.
@@ -207,6 +222,8 @@ class BuilderBase(object):
 
         if self.test:
             self._setup_test_specfile()
+        
+        self._copy_extra_sources()
 
         debug("Creating srpm from spec file: %s" % self.spec_file)
         define_dist = ""

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -211,7 +211,6 @@ class BuilderBase(object):
                 debug("Copying %s -> %s" % (src, self.rpmbuild_sourcedir))
                 shutil.copy(src, self.rpmbuild_sourcedir)
 
-
     def srpm(self, dist=None):
         """
         Build a source RPM.
@@ -222,7 +221,7 @@ class BuilderBase(object):
 
         if self.test:
             self._setup_test_specfile()
-        
+
         self._copy_extra_sources()
 
         debug("Creating srpm from spec file: %s" % self.spec_file)

--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -348,12 +348,15 @@ class BuildModule(BaseCliModule):
         self.parser.add_option("--scl", dest='scl',
                 default='',
                 metavar="COLLECTION", help="Build package for software collection.")
+        self.parser.add_option("--project-name", dest='project_name', default=None, help="Force project name. " +
+                "This can used to avoid early specfile parsing. If you have %include directive on" +
+                "your specfile this can help.")
 
     def main(self, argv):
         BaseCliModule.main(self, argv)
 
         build_dir = os.path.normpath(os.path.abspath(self.options.output_dir))
-        package_name = get_project_name(tag=self.options.tag)
+        package_name = get_project_name(tag=self.options.tag) if self.options.project_name is None else self.options.project_name
 
         build_tag = self.options.tag
 

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -445,7 +445,7 @@ def run_command_print(command):
     env['LC_ALL'] = 'C'
     p = None
     try:
-        p = subprocess.Popen(shlex.split(command),
+        p = subprocess.Popen(command, shell=True,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env,
             universal_newlines=True)
     except OSError as e:

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -814,7 +814,7 @@ def get_project_name(tag=None, scl=None):
                 "rpm -q --qf '%%{name}\n' %s --specfile %s 2> /dev/null | grep -e '^$' -v | head -1" %
                 (scl_to_rpm_option(scl, silent=True), file_path))
             if not output:
-                error_out(["Unable to determine project name from spec file: %s foooooooo" % file_path,
+                error_out(["Unable to determine project name from spec file: %s" % file_path,
                     "Try rpm -q --specfile %s" % file_path,
                     "Try rpmlint -i %s" % file_path])
             return output

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -814,7 +814,7 @@ def get_project_name(tag=None, scl=None):
                 "rpm -q --qf '%%{name}\n' %s --specfile %s 2> /dev/null | grep -e '^$' -v | head -1" %
                 (scl_to_rpm_option(scl, silent=True), file_path))
             if not output:
-                error_out(["Unable to determine project name from spec file: %s" % file_path,
+                error_out(["Unable to determine project name from spec file: %s foooooooo" % file_path,
                     "Try rpm -q --specfile %s" % file_path,
                     "Try rpmlint -i %s" % file_path])
             return output


### PR DESCRIPTION
The rpm spec system support including files with the `%include` directive. This enable packagers to achieve some level of code re-usage.

# The chicken/egg problem.

`tito` tries to parse the spec file to get the project name. But when the spec file contains an `%include` directive this parsing fails because the included file can't be found. Usually files are included in conjunction of the `SOURCE` directive. So for example:

```
SOURCE0: %{name}-%{version}.tar.gz
SOURCE1: somecool.macros
...
%include %{SOURCE1}
```

`somecool.macros` is expected to be inside the .src.rpm.

# What this PR does?

This PR add one option `--project-name` to avoid early parsing of the spec file, and search for `SOURCE` lines at the spec files. For each `SOURCE` line found the source file is copied to the .src.rpm. With this is possible to use `%include` directive as expected.