### PR TITLE
Avoid double builds with mock

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -1150,9 +1150,6 @@ class MockBuilder(Builder):
         else:
             print("Skipping mock --init due to speedup option.")
 
-        print("Installing deps in mock...")
-        run_command_func("mock %s -r %s %s" % (
-            self.mock_cmd_args, self.mock_tag, self.srpm_location))
         print("Building RPMs in mock...")
         run_command_func('mock %s -r %s --rebuild %s' %
                 (self.mock_cmd_args, self.mock_tag, self.srpm_location))


### PR DESCRIPTION
According to mock man page the default behavior without a command flag is to run --rebuild.
This change avoids what is essentially doing --rebuild twice.

```
       --rebuild
              If no command is specified, rebuild is assumed. Rebuild the specified SRPM(s). The chroot (including the results directory) is cleaned first, unless --no-clean is specified.

```