### PR TITLE
use built-in shutil.copy2 instead of relying external cp file globbing

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -1162,8 +1162,8 @@ class MockBuilder(Builder):
 
         # Copy everything mock wrote out to /tmp/tito:
         files = os.listdir(mock_output_dir)
-        run_command_func("cp -v %s/*.rpm %s" %
-                (mock_output_dir, self.rpmbuild_basedir))
+        for rpm in files:
+            shutil.copy2(os.path.join(mock_output_dir, rpm), self.rpmbuild_basedir)
         print
         info_out("Wrote:")
         for rpm in files:


### PR DESCRIPTION
Had the following failure after upgrading to tito 0.6.11 and mock 1.4.9 on CentOS7 building CentOS5 packages, I guessed that possibly the file glob wasn't being interpreted by the external command, changing the relevant code to use shutil.copy2 instead resolved the issue.  I didn't figure out why this behavior changed but it would seem that using the built-in file copy support is generally better than forking cp.  HTH

```
Traceback (most recent call last):
  File "/bin/tito", line 23, in <module>
    CLI().main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 203, in main
    return module.main(argv)
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 598, in main
    scratch=self.options.scratch)
  File "/usr/lib/python2.7/site-packages/tito/release/main.py", line 264, in release
    self.builder.rpm()
  File "/usr/lib/python2.7/site-packages/tito/builder/main.py", line 1139, in rpm
    self._build_in_mock()
  File "/usr/lib/python2.7/site-packages/tito/builder/main.py", line 1166, in _build_in_mock
    (mock_output_dir, self.rpmbuild_basedir))
  File "/usr/lib/python2.7/site-packages/tito/common.py", line 468, in run_command_print
    raise RunCommandException(command, status, "\n".join(output))
tito.exception.RunCommandException: Error running command: cp -v /tmp/tito/rpmbuild-<package_name><rand>/mockoutput/*.rpm /tmp/tito

```