### PR TITLE
Revert "use built-in shutil.copy2 instead of relying external cp file globbing"

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -1159,8 +1159,8 @@ class MockBuilder(Builder):
 
         # Copy everything mock wrote out to /tmp/tito:
         files = os.listdir(mock_output_dir)
-        for rpm in files:
-            shutil.copy2(os.path.join(mock_output_dir, rpm), self.rpmbuild_basedir)
+        run_command_func("cp -v %s/*.rpm %s" %
+                (mock_output_dir, self.rpmbuild_basedir))
         print
         info_out("Wrote:")
         for rpm in files:


### PR DESCRIPTION
Reverts dgoodwin/tito#318

Checking if this will fix the build.