### PR TITLE
Do not touch tests/ or gating.yaml in dist-git

### DIFF
--- a/src/tito/release/main.py
+++ b/src/tito/release/main.py
@@ -29,7 +29,7 @@ from tito.exception import TitoException
 from tito.config_object import ConfigObject
 
 # List of files to protect when syncing:
-PROTECTED_BUILD_SYS_FILES = ('branch', 'Makefile', 'sources', ".git", ".gitignore", ".osc", "tito-mead-url")
+PROTECTED_BUILD_SYS_FILES = ('branch', 'Makefile', 'sources', ".git", ".gitignore", ".osc", "tito-mead-url", "tests", "gating.yaml")
 
 RSYNC_USERNAME = 'RSYNC_USERNAME'  # environment variable name
 


### PR DESCRIPTION
- `tests/` is part of Fedora's Standard Test Interface (see https://fedoraproject.org/wiki/CI/Standard_Test_Interface )
- `gating.yaml` is part of Fedora's CI/Gating (see https://fedoraproject.org/wiki/CI/Gating )