### PR TITLE
Enable GnuPG signed tags

### DIFF
--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -488,7 +488,13 @@ class VersionTagger(ConfigObject):
                 (self.project_name, new_tag,
                         self.relative_project_dir)
 
-        run_command('git tag -m "%s" %s' % (tag_msg, new_tag))
+        # Optionally gpg sign the tag
+        sign_tag = ""
+        if self.config.has_option(BUILDCONFIG_SECTION, "sign_tag"):
+            if self.config.getboolean(BUILDCONFIG_SECTION, "sign_tag"):
+                sign_tag = "-s "
+
+        run_command('git tag %s -m "%s" %s' % (sign_tag, tag_msg, new_tag))
         print
         info_out("Created tag: %s" % new_tag)
         print("   View: git show HEAD")

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -85,6 +85,9 @@ This option controls the format used in VersionTagger. If not specified
 default format would be '{component}-{version}-{release}'. It won't affect
 other taggers.
 
+sign_tag::
+This boolean enables GnuPG signed tags using 'git tag -s'.
+
 KOJI and COPR
 -------------
 


### PR DESCRIPTION
Add 'sign_tag = 1' to the [buildconfig] section of tito.props to enable it.