### PR TITLE
make get_project_name more resilient

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -810,7 +810,7 @@ def get_project_name(tag=None, scl=None):
     current working directory. Error out if neither is present.
     """
     if tag is not None:
-        p = re.compile('(.*?)-(\d.*)')
+        p = re.compile('(.*?)-(\d[^-]*)(-[^-]*)?$')
         m = p.match(tag)
         if not m:
             error_out("Unable to determine project name in tag: %s" % tag)

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -810,11 +810,14 @@ def get_project_name(tag=None, scl=None):
     current working directory. Error out if neither is present.
     """
     if tag is not None:
-        p = re.compile('(.*?)-(\d[^-]*)(-[^-]*)?$')
-        m = p.match(tag)
-        if not m:
-            error_out("Unable to determine project name in tag: %s" % tag)
-        return m.group(1)
+        try:
+            (package, _version, _release) = tag.rsplit('-', 2)
+        except ValueError:
+            try:
+                (package, _version) = tag.rsplit('-', 1)
+            except ValueError:
+                error_out("Unable to determine project name in tag: %s" % tag)
+        return package
     else:
         file_path = find_spec_like_file()
         if not os.path.exists(file_path):

--- a/test/unit/common_tests.py
+++ b/test/unit/common_tests.py
@@ -17,7 +17,7 @@ from tito.common import (replace_version, find_spec_like_file, increase_version,
     search_for, compare_version, run_command_print, find_wrote_in_rpmbuild_output,
     render_cheetah, increase_zstream, reset_release, find_file_with_extension,
     normalize_class_name, extract_sha1, BugzillaExtractor, DEFAULT_BUILD_DIR, munge_specfile,
-    munge_setup_macro,
+    munge_setup_macro, get_project_name,
     _out)
 
 from tito.compat import StringIO
@@ -221,6 +221,23 @@ class CommonTests(unittest.TestCase):
         _out('Hello world', None, Terminal().red, stream)
         # RHEL 6 doesn't have self.assertRegexpMatches unfortunately
         self.assertTrue(re.match('.+Hello world.+\n', stream.getvalue()))
+
+    def test_get_project_name(self):
+        TAGS = [
+            ('package-1.0-1', 'package'),
+            ('package-1.0', 'package'),
+            ('long-package-name-that-should-not-be-an-issue-0.1-1', 'long-package-name-that-should-not-be-an-issue'),
+            ('package-with-weird-version-0.1-0.1.beta1', 'package-with-weird-version'),
+            ('grub2-efi-ia32-1.0-1', 'grub2-efi-ia32'),
+            ('iwl5150-firmware-1.0-1', 'iwl5150-firmware'),
+            ('389-ds-base-1.0-1', '389-ds-base'),
+            ('avr-gcc-c++-1.0-1', 'avr-gcc-c++'),
+            ('java-1.8.0-openjdk-1.8.0.232.b09-0', 'java-1.8.0-openjdk'),
+            ('jsr-305-0-0.25.20130910svn', 'jsr-305')
+        ]
+
+        for (tag, package) in TAGS:
+            self.assertEquals(package, get_project_name(tag, None))
 
 
 class CheetahRenderTest(unittest.TestCase):


### PR DESCRIPTION
before this, packages with a name like "foo-1-setup" would be end up
parsed as "foo" and confused the heck out of the whitelisting code.

~~the new regex is less greedy about numbers by expecting the tag to end
in something that looks like a version (any number of numbers, dots and
hyphens) followed by an optional "dash anything" for the release.~~

split tag instead of parsing it using a regex as nothing says that the version number must start with a number as seen in the gpg-pubkey packages in Fedora:

    gpg-pubkey-facb00b1-570a8081
