### PR TITLE
tar.py: fix implicit ascii decode of unicode data

### DIFF
--- a/src/tito/tar.py
+++ b/src/tito/tar.py
@@ -193,9 +193,9 @@ class TarFixer(object):
                 field_size = int(re.match('(\d+)', member_template).group(1)) - 1
                 fmt = "%0" + str(field_size) + "o\x00"
                 as_string = fmt % chunk_props[member]
-                pack_values.append(as_string.encode("utf8"))
+                pack_values.append(as_string.decode("utf8").encode("utf8"))
             else:
-                pack_values.append(chunk_props[member].encode("utf8"))
+                pack_values.append(chunk_props[member].decode("utf8").encode("utf8"))
         return pack_values
 
     def process_header(self, chunk_props):


### PR DESCRIPTION
Given a tarball with a utf8 filename, this was getting errors like `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 75: ordinal not in range(128)`
The problem is that in order to encode as utf8, it needed to first have a unicode, and so it implicitly decodes to unicode first. However the default decoding is ascii, and the actual contents of the tarball headers contain utf8.
This makes explicit the decoding as utf8, which should cover ascii and utf8 inputs.