### PR TITLE
Update common.py

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -917,6 +917,7 @@ def get_commit_count(tag, commit_id):
         debug("going to use number of commits from initial commit")
         (status, output) = getstatusoutput(
             "git rev-list --max-parents=0 HEAD")
+        output = output.split("\n")[-1]
         if status == 0:
             # output is now inital commit
             (status, output) = getstatusoutput(


### PR DESCRIPTION
Add in a check to confirm we get the original root commit has in case there are multiple. This can occur when two separate repositories are merged in to one new one. Without this addition the count will always return 0.