### PR TITLE
Merge downstream patches

### DIFF
--- a/tito.spec
+++ b/tito.spec
@@ -23,8 +23,8 @@ Summary: A tool for managing rpm based git projects
 
 Group: Development/Tools
 License: GPLv2
-URL: http://rm-rf.ca/tito
-Source0: http://rm-rf.ca/files/tito/tito-%{version}.tar.gz
+URL: https://github.com/dgoodwin/tito
+Source0: https://github.com/dgoodwin/tito/archive/tito-%{version}-1.tar.gz
 
 BuildArch: noarch
 %if %{use_python3}
@@ -77,7 +77,10 @@ Tito is a tool for managing tarballs, rpms, and builds for projects using
 git.
 
 %prep
-%setup -q -n tito-%{version}
+# the weird directory name is because github makes the directory name
+# '(projectname)-(tag)', and the tags for tito have 'tito' in them and
+# '-1' on the end...
+%setup -q -n tito-tito-%{version}-1
 sed -i 1"s|#!.*|#!%{ourpythonbin}|" bin/tito
 
 %build

--- a/tito.spec
+++ b/tito.spec
@@ -64,9 +64,6 @@ BuildRequires: rpm-python3
 Requires: rpm-build
 Requires: rpmlint
 Requires: fedpkg
-%if 0%{?fedora} && 0%{?fedora} < 31
-Requires: fedora-cert
-%endif
 Requires: fedora-packager
 Requires: rpmdevtools
 # Cheetah doesn't exist for Python 3, but it's what Mead uses.  We

--- a/tito.spec
+++ b/tito.spec
@@ -114,8 +114,8 @@ install -Dp -m 0644 share/tito_completion.sh %{buildroot}%{_datadir}/bash-comple
 %{_bindir}/generate-patches.pl
 %{_datadir}/bash-completion/completions/tito
 %dir %{python_sitelib}/tito
-%{python_sitelib}/tito/*
-%{python_sitelib}/tito-*.egg-info
+%{python2_sitelib}/tito/*
+%{python2_sitelib}/tito-*.egg-info
 
 
 %changelog

--- a/tito.spec
+++ b/tito.spec
@@ -21,7 +21,6 @@ Version: 0.6.11
 Release: 1%{?dist}
 Summary: A tool for managing rpm based git projects
 
-Group: Development/Tools
 License: GPLv2
 URL: https://github.com/dgoodwin/tito
 Source0: https://github.com/dgoodwin/tito/archive/tito-%{version}-1.tar.gz

--- a/tito.spec
+++ b/tito.spec
@@ -66,10 +66,11 @@ Requires: rpmlint
 Requires: fedpkg
 Requires: fedora-packager
 Requires: rpmdevtools
-# Cheetah doesn't exist for Python 3, but it's what Mead uses.  We
+# Cheetah used not to exist for Python 3, but it's what Mead uses.  We
 # install it and call via the command line instead of importing the
-# potentially incompatible code
-Requires: python-cheetah
+# previously potentially incompatible code, as we have not yet got
+# around to changing this
+Requires: /usr/bin/cheetah
 
 %description
 Tito is a tool for managing tarballs, rpms, and builds for projects using

--- a/tito.spec
+++ b/tito.spec
@@ -102,9 +102,6 @@ cp -a tito.8 %{buildroot}/%{_mandir}/man8/
 # bash completion facilities
 install -Dp -m 0644 share/tito_completion.sh %{buildroot}%{_datadir}/bash-completion/completions/tito
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
 
 %files
 %doc AUTHORS COPYING

--- a/tito.spec
+++ b/tito.spec
@@ -35,7 +35,7 @@ Requires: python3-bugzilla
 Requires: python3-blessings
 Requires: rpm-python3
 %else
-BuildRequires: python-devel
+BuildRequires: python2-devel
 BuildRequires: python-setuptools
 Requires: python-setuptools
 Requires: python-bugzilla

--- a/tito.spec
+++ b/tito.spec
@@ -1,20 +1,20 @@
 %if 0%{?rhel} > 7 || 0%{?fedora}
 %global use_python3 1
 %global use_python2 0
-%global pythonbin %{__python3}
-%global python_sitelib %{python3_sitelib}
+%global ourpythonbin %{__python3}
+%global our_sitelib %{python3_sitelib}
 %else
 %global use_python3 0
 %global use_python2 1
 %if 0%{?__python2:1}
-%global pythonbin %{__python2}
-%global python_sitelib %{python2_sitelib}
+%global ourpythonbin %{__python2}
+%global our_sitelib %{python2_sitelib}
 %else
-%global pythonbin %{__python}
-%global python_sitelib %{python_sitelib}
+%global ourpythonbin %{__python}
+%global our_sitelib %{our_sitelib}
 %endif
 %endif
-%{!?python_sitelib: %define python_sitelib %(%{pythonbin} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+%{!?our_sitelib: %define our_sitelib %(%{ourpythonbin} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Name: tito
 Version: 0.6.11
@@ -77,10 +77,10 @@ git.
 
 %prep
 %setup -q -n tito-%{version}
-sed -i 1"s|#!.*|#!%{pythonbin}|" bin/tito
+sed -i 1"s|#!.*|#!%{ourpythonbin}|" bin/tito
 
 %build
-%{pythonbin} setup.py build
+%{ourpythonbin} setup.py build
 # convert manages
 a2x -d manpage -f manpage titorc.5.asciidoc
 a2x -d manpage -f manpage tito.8.asciidoc
@@ -89,8 +89,8 @@ a2x -d manpage -f manpage releasers.conf.5.asciidoc
 
 %install
 rm -rf $RPM_BUILD_ROOT
-%{pythonbin} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
-rm -f $RPM_BUILD_ROOT%{python_sitelib}/*egg-info/requires.txt
+%{ourpythonbin} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
+rm -f $RPM_BUILD_ROOT%{our_sitelib}/*egg-info/requires.txt
 # manpages
 %{__mkdir_p} %{buildroot}%{_mandir}/man5
 %{__mkdir_p} %{buildroot}%{_mandir}/man8
@@ -110,9 +110,9 @@ install -Dp -m 0644 share/tito_completion.sh %{buildroot}%{_datadir}/bash-comple
 %{_bindir}/tito
 %{_bindir}/generate-patches.pl
 %{_datadir}/bash-completion/completions/tito
-%dir %{python_sitelib}/tito
-%{python2_sitelib}/tito/*
-%{python2_sitelib}/tito-*.egg-info
+%dir %{our_sitelib}/tito
+%{our_sitelib}/tito/*
+%{our_sitelib}/tito-*.egg-info
 
 
 %changelog


### PR DESCRIPTION
I found several downstream patches here
https://src.fedoraproject.org/rpms/tito/commits/f31

Without them, tito is not installable (because of `fedora-cert`, but I've applied them all).