### PR TITLE
Move to python-blessed

### DIFF
--- a/hacking/titotest-centos-6/Dockerfile
+++ b/hacking/titotest-centos-6/Dockerfile
@@ -25,7 +25,7 @@ RUN yum -y install \
     docbook-style-xsl \
     libxslt \
     rpmdevtools \
-    python-blessings \
+    python-blessed \
     ; yum clean all
 
 RUN useradd sandbox

--- a/hacking/titotest-centos-7/Dockerfile
+++ b/hacking/titotest-centos-7/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y install           \
            docbook-style-xsl \
            libxslt           \
            rpmdevtools       \
-           python-blessings  \
+           python-blessed    \
     && yum clean all
 
 RUN useradd sandbox

--- a/hacking/titotest-fedora-27/Dockerfile
+++ b/hacking/titotest-fedora-27/Dockerfile
@@ -8,14 +8,14 @@ RUN dnf -y install                 \
            python2-devel           \
            python-mock             \
            python-nose             \
-           python-blessings        \
+           python-blessed          \
            python-pep8             \
            python-setuptools       \
            python-bugzilla         \
            python2-rpm             \
            python3-mock            \
            python3-nose            \
-           python3-blessings       \
+           python3-blessed         \
            python3-pep8            \
 	   rsync                   \
            createrepo_c

--- a/hacking/titotest-fedora-rawhide/Dockerfile
+++ b/hacking/titotest-fedora-rawhide/Dockerfile
@@ -14,14 +14,13 @@ RUN dnf -y install          \
     python2-devel           \
     python-mock             \
     python-nose             \
-    python-blessings        \
     python-pep8             \
     python-setuptools       \
     python-bugzilla         \
     python2-rpm             \
     python3-mock            \
     python3-nose            \
-    python3-blessings       \
+    python3-blessed         \
     python3-pep8            \
     rsync                   \
     createrepo_c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-blessings
+blessed

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages('src'),
     include_package_data=True,
     install_requires=[
-        'blessings'
+        'blessed'
     ],
 
     # non-python scripts go here

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -28,7 +28,7 @@ import shlex
 import shutil
 import tempfile
 
-from blessings import Terminal
+from blessed import Terminal
 
 from bugzilla.rhbugzilla import RHBugzilla
 

--- a/test/unit/common_tests.py
+++ b/test/unit/common_tests.py
@@ -31,7 +31,7 @@ from mock import Mock, patch, call
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from unit import open_mock, Capture
-from blessings import Terminal
+from blessed import Terminal
 
 
 class CommonTests(unittest.TestCase):

--- a/tito.spec
+++ b/tito.spec
@@ -31,14 +31,14 @@ BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 Requires: python3-setuptools
 Requires: python3-bugzilla
-Requires: python3-blessings
+Requires: python3-blessed
 Requires: rpm-python3
 %else
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 Requires: python-setuptools
 Requires: python-bugzilla
-Requires: python-blessings
+Requires: python-blessed
 Requires: rpm-python
 %endif
 BuildRequires: asciidoc


### PR DESCRIPTION
As python-blessings is unmaintained nowadays and is not packaged for
EPEL 8, it might be good to move to an active fork.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1777377