### PR TITLE
Allow including macros through SourceX

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -197,6 +197,21 @@ class BuilderBase(object):
             mkdir_p(d)
         self._check_build_dirs_access(build_dirs)
 
+    def _copy_extra_sources(self):
+        """
+        Copy extra %{SOURCEX} files to the SOURCE folder.
+        """
+        with open(self.spec_file, 'r') as spec:
+            for line in spec.readlines():
+                match = re.match(r'SOURCE[1-9]\d*:(?P<src>.*)', line, re.I)
+                if match is None:
+                    continue
+
+                src = os.path.join(self.rpmbuild_sourcedir, self.tgz_dir, match.group('src').strip())
+                debug("Copying %s -> %s" % (src, self.rpmbuild_sourcedir))
+                shutil.copy(src, self.rpmbuild_sourcedir)
+
+
     def srpm(self, dist=None):
         """
         Build a source RPM.
@@ -207,6 +222,8 @@ class BuilderBase(object):
 
         if self.test:
             self._setup_test_specfile()
+        
+        self._copy_extra_sources()
 
         debug("Creating srpm from spec file: %s" % self.spec_file)
         define_dist = ""

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -208,6 +208,9 @@ class BuilderBase(object):
                     continue
 
                 src = os.path.join(self.rpmbuild_sourcedir, self.tgz_dir, match.group('src').strip())
+                if os.path.islink(src) and os.path.isabs(src):
+                    src = os.path.join(self.start_dir, os.readlink(src))
+
                 debug("Copying %s -> %s" % (src, self.rpmbuild_sourcedir))
                 shutil.copy(src, self.rpmbuild_sourcedir)
 

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -211,7 +211,6 @@ class BuilderBase(object):
                 debug("Copying %s -> %s" % (src, self.rpmbuild_sourcedir))
                 shutil.copy(src, self.rpmbuild_sourcedir)
 
-
     def srpm(self, dist=None):
         """
         Build a source RPM.
@@ -222,7 +221,7 @@ class BuilderBase(object):
 
         if self.test:
             self._setup_test_specfile()
-        
+
         self._copy_extra_sources()
 
         debug("Creating srpm from spec file: %s" % self.spec_file)
@@ -269,6 +268,7 @@ class BuilderBase(object):
         self._create_build_dirs()
         if not self.ran_tgz:
             self.tgz()
+        self._copy_extra_sources()
 
         cmd = 'rpmbuild {0}'.format(
             " ".join([

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -827,9 +827,12 @@ def get_project_name(tag=None, scl=None):
             name = search_for(file_path, r"\s*Name:\s*(.*?)\s*$")[0][0]
             return name
         else:
+            sourcedir = os.path.dirname(file_path)
             output = run_command(
-                "rpm -q --qf '%%{name}\n' %s --specfile %s 2> /dev/null | grep -e '^$' -v | head -1" %
-                (scl_to_rpm_option(scl, silent=True), file_path))
+                "rpm -q --qf '%%{name}\n' %s --specfile %s --define '_sourcedir %s' "
+                "2> /dev/null | grep -e '^$' -v | head -1" %
+                (scl_to_rpm_option(scl, silent=True), file_path, sourcedir))
+
             if not output:
                 error_out(["Unable to determine project name from spec file: %s" % file_path,
                     "Try rpm -q --specfile %s" % file_path,


### PR DESCRIPTION
Fix: #311
Supersedes: #313

The `get_project_name` function is called in an early phase when
the temporary `SOURCES` directory for a current build doesn't exist yet.
Therefore as a little workaround, we set `_sourcedir` to an upstream
directory containing the package spec file.

Defining a custom `_sourcedir` (and therefore not using
`~/rpmbuild/SOURCES`) shouldn't be a problem because tito builds
should not depend on anything outside of the upstream git repository.

The use-case described in PR#313 works as expected.

        SOURCE1: somecool.macros
        %include %{SOURCE1}

For multi-spec projects, where you have e.g

        .
        ├── foo
        │   ├── foo.spec
        ├── bar
        │   ├── bar.spec

It is possible to include the common macros from a parent (or some
other) directory by having a symlink.

        cd foo
        ln -s ../somecool.macros ./

Or possibly some other way which I am currently not aware of
because I wasn't able to e.g. persuade `%include` to include from
the parent directory.
