### PR TITLE
Fix travis CI tests for Fedora Rawhide

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -536,8 +536,8 @@ class Builder(ConfigObject, BuilderBase):
         run_command("cd %s/ && tar xzf %s" % (self.rpmbuild_sourcedir,
             self.tgz_filename))
 
-        # Show contents of the directory structure we just extracted.
-        debug('', 'ls -lR %s/' % self.rpmbuild_gitcopy)
+        debug("Show contents of the directory structure we just extracted:\n%s"
+              % os.listdir(self.rpmbuild_gitcopy))
 
         # NOTE: The spec file we actually use is the one exported by git
         # archive into the temp build directory. This is done so we can


### PR DESCRIPTION
Do not run external ls -lR command to debug directory content
    
When running tests for fedora rawhide in Travis, this debug line
fails with following error:
    
    Command output: ls: cannot access
    '/tmp/tmpjw15wzfs-titotest/rpmbuild-titotestpkg24v2hy67/SOURCES/titotestpkg-0.0.1/':
    Operation not permitted
    
Even when changing the debug line to just
    
    debug('', 'ls -l /')
    
it still fails. Let's just use `os.listdir`