### PR TITLE
Fix version checking with setuptools 82

### DIFF
--- a/.github/workflows/fedora-tox.yml
+++ b/.github/workflows/fedora-tox.yml
@@ -30,6 +30,7 @@ jobs:
             libxslt
             python3-bugzilla
             python3-rpm
+            python3-setuptools
             rpm-build
             rpmdevtools
             rsync


### PR DESCRIPTION
Fix #514

As of today, Fedora Rawhide (F45) only has
`python3-setuptools-80.10.2-1.fc44.noarch`, so at the moment, the issue only happens when installing Tito from PyPI.