### PR TITLE
Fixing rhel macro condition and removing blessed from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages('src'),
     include_package_data=True,
     install_requires=[
-        'blessed'
+        
     ],
 
     # automatically create console scripts

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -28,7 +28,14 @@ import shlex
 import shutil
 import tempfile
 
-from blessed import Terminal
+try:
+    from blessed import Terminal
+except ImportError:
+    class Terminal(object):
+        def __getattr__(self, name):
+            def wrapper(text, *args, **kwargs):
+                return text
+            return wrapper
 
 from tito.compat import getstatusoutput
 from tito.exception import RunCommandException

--- a/test/unit/common_tests.py
+++ b/test/unit/common_tests.py
@@ -21,7 +21,16 @@ from unittest.mock import patch, call
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from unit import open_mock, Capture, titodir
-from blessed import Terminal
+try:
+    from blessed import Terminal
+    BLESSED_AVAILABLE = True
+except ImportError:
+    BLESSED_AVAILABLE = False
+    class Terminal(object):
+        def __getattr__(self, name):
+            def wrapper(text, *args, **kwargs):
+                return text
+            return wrapper
 
 # Pure unit tests for tito's common module
 from tito.common import (replace_version, find_spec_like_file, increase_version,
@@ -216,6 +225,7 @@ class CommonTests(unittest.TestCase):
         _out('Hello world', None, Terminal().red, stream)
         self.assertEqual('Hello world\n', stream.getvalue())
 
+    @unittest.skipUnless(BLESSED_AVAILABLE, "blessed module not available")
     @patch("tito.common.read_user_config")
     def test_colors(self, mock_user_conf):
         mock_user_conf.return_value = {}

--- a/tito.spec
+++ b/tito.spec
@@ -40,7 +40,9 @@ BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 Requires: python3-setuptools
 Requires: python3-bugzilla
+%if 0%{?fedora} || (1%{?rhel} > 10 && 1%{?rhel} < 110)
 Requires: python3-blessed
+%endif
 Requires: rpm-python3
 Recommends: python3-fedora-distro-aliases
 %else
@@ -63,7 +65,9 @@ BuildRequires: which
 BuildRequires: createrepo_c
 BuildRequires: git-core
 BuildRequires: rsync
+%if 0%{?fedora} || (1%{?rhel} > 10 && 1%{?rhel} < 110)
 BuildRequires: python3-blessed
+%endif
 BuildRequires: python3-bugzilla
 BuildRequires: python3-pycodestyle
 BuildRequires: python3-pytest


### PR DESCRIPTION
This is a potential fix to the build failure on EPEL 10. The issue appears to be that the python3-blessed package which is available in EPEL for RHEL9 is not yet available for EPEL 10. The simple fix below was generated with some help from AI. I have, however, verified that it builds on both Centos 9 and 10. If there are any concerns with the code, or if you would prefer to wait until python3-blessed makes it's way into EPEL, feel free to reject this request.